### PR TITLE
sanitize description on exception.

### DIFF
--- a/src/SPTSenTestCase.m
+++ b/src/SPTSenTestCase.m
@@ -112,8 +112,9 @@
         description = [NSString stringWithFormat:@"%@\n  Call Stack:\n    %@", description, [callStack componentsJoinedByString:@"\n    "]];
       }
     }
+    NSString * sanitizedDescription = [description stringByReplacingOccurrencesOfString:@"%@" withString:@"?"];
     exception = [NSException exceptionWithName:name reason:description
-                             userInfo:[[NSException failureInFile:file atLine:0 withDescription:description] userInfo]];
+                             userInfo:[[NSException failureInFile:file atLine:0 withDescription:sanitizedDescription] userInfo]];
   }
   SPTSenTestCase *currentTestCase = [[[NSThread currentThread] threadDictionary] objectForKey:@"SPT_currentTestCase"];
   [currentTestCase.SPT_run addException:exception];

--- a/test/UnexpectedExceptionTest.m
+++ b/test/UnexpectedExceptionTest.m
@@ -5,7 +5,7 @@
 static BOOL shouldRaiseException = NO;
 
 static void raiseException() {
-  [[NSException exceptionWithName:@"MyException" reason:@"Oh Noes!" userInfo:nil] raise];
+  [[NSException exceptionWithName:@"MyException" reason:@"Oh Noes! %@" userInfo:nil] raise];
 }
 
 SpecBegin(_UnexpectedExceptionTest)


### PR DESCRIPTION
Hi Pete,

This pull-request is to fix EXC_BAD_ACCESS error when exception was raised and the description (from [NSException reason] or from the symbols stack) somehow contains '%@'.

The fix simply sanitize the description by replacing occurrence of '%@' with '?'.

I'm encontering this when testing core data codes where using a lot of %@ in the NSPredicate.

-Meiwin
