### PR TITLE
Allow a custom test case class with SpecBegin

### DIFF
--- a/src/SpectaSupport.h
+++ b/src/SpectaSupport.h
@@ -1,5 +1,9 @@
+#ifndef SPT_SUBCLASS
+#define SPT_SUBCLASS SPTSenTestCase
+#endif
+
 #define _SPT_SpecBegin(name, file, line) \
-@interface name##Spec : SPTSenTestCase \
+@interface name##Spec : SPT_SUBCLASS \
 @end \
 @implementation name##Spec \
 - (void)SPT_defineSpec { \


### PR DESCRIPTION
Defining `SPT_SUBCLASS` before importing Specta will use the named class for test cases, instead of `SPTSenTestCase`.
