### PR TITLE
Make itShouldBehaveLike evaluate lazily

### DIFF
--- a/src/Specta.m
+++ b/src/Specta.m
@@ -72,9 +72,11 @@ void sharedExamples(NSString *name, void (^block)(NSDictionary *data)) {
 
 void itShouldBehaveLike(NSString *name, NSDictionary *data) {
   SPTDictionaryBlock block = [SPTSharedExampleGroups sharedExampleGroupWithName:name exampleGroup:SPT_currentGroup];
-  if(block) {
-    block(data);
-  }
+  example(name, ^{
+    if(block) {
+      block(data);
+    }
+  });
 }
 
 void itBehavesLike(NSString *name, NSDictionary *data) {


### PR DESCRIPTION
I noticed that itShouldBehaveLike evaluates immediately. This required you to supply the data up front instead of via something like a beforeEach/BeforeAll. Adding the shared evaluation to the current group seems to fix it, but I'm not sure what other effects that may have.
