### PR TITLE
Remove nonexistent header search path

### DIFF
--- a/Specta.podspec
+++ b/Specta.podspec
@@ -20,6 +20,7 @@ Pod::Spec.new do |s|
 
   s.frameworks = 'Foundation', 'SenTestingKit'
 
-  s.xcconfig = { 'FRAMEWORK_SEARCH_PATHS' => '"$(SDKROOT)/Developer/Library/Frameworks" "$(DEVELOPER_LIBRARY_DIR)/Frameworks"' }
+  s.ios.xcconfig    = { 'FRAMEWORK_SEARCH_PATHS' => '$(inherited) "$(SDKROOT)/Developer/Library/Frameworks" "$(DEVELOPER_LIBRARY_DIR)/Frameworks"' }
+  s.osx.xcconfig    = { 'FRAMEWORK_SEARCH_PATHS' => '$(inherited) "$(DEVELOPER_LIBRARY_DIR)/Frameworks"' }
 end
 


### PR DESCRIPTION
`$(SDKROOT)/Developer/Library/Frameworks` does not exist for the OS X SDK
