### PR TITLE
Fix OCHamcrest inside an example group

### DIFF
--- a/src/SPTSharedExampleGroups.m
+++ b/src/SPTSharedExampleGroups.m
@@ -1,5 +1,6 @@
 #import "SPTSharedExampleGroups.h"
 #import "SPTExampleGroup.h"
+#import "SPTSenTestCase.h"
 #import <objc/runtime.h>
 
 NSMutableDictionary *globalSharedExampleGroups = nil;
@@ -54,5 +55,11 @@ BOOL initialized = NO;
 }
 
 + (void)defineSharedExampleGroups {}
+
++ (void)failWithException:(NSException *)exception
+{
+    SPTSenTestCase *currentTestCase = [[[NSThread currentThread] threadDictionary] objectForKey:@"SPT_currentTestCase"];
+    [currentTestCase failWithException: exception];
+}
 
 @end


### PR DESCRIPTION
OCHamcrest captures self, assuming that it is a SenTestCase. When called from within an example group, this doesn't fail the correct test case when being run and instead crashes.

Adding `failWithException:` to `SPTSharedExampleGroups.m`, which passes through to the current test case, makes hamcrest matchers work properly in example groups.
