### PR TITLE
Raise an exception when nonexistent shared examples are referenced

### DIFF
--- a/src/Specta.m
+++ b/src/Specta.m
@@ -137,6 +137,10 @@ void itShouldBehaveLike(NSString *name, id dictionaryOrBlock) {
       NSException *exception = [NSException failureInFile:spec.fileName atLine:(int)spec.lineNumber withDescription:@"itShouldBehaveLike should not be invoked inside an example block!"];
       [currentTestCase failWithException: exception];
     }
+    else {
+      [NSException raise:NSInvalidArgumentException
+                  format:@"Shared example group \"%@\" does not exist.", name];
+    }
   }
 }
 


### PR DESCRIPTION
The following spec will silently pass:

```
SpecBegin(_SharedExamplesTest6)

itShouldBehaveLike(@"nonexistent behavior", nil);

SpecEnd
```

I think it should trigger an exception that points out that the shared example group "nonexistent behavior" is undefined. 

This pull request makes it so. However, I couldn't find a way to test the changes since Specta eats up all exceptions that occur outside an example (and then calls `exit(1)`).
