### PR TITLE
Add -SPT_setUp and -SPT_tearDown to run global cleanup/teardown

### DIFF
--- a/src/SPTExample.h
+++ b/src/SPTExample.h
@@ -1,16 +1,20 @@
 #import <Foundation/Foundation.h>
 #import "SpectaTypes.h"
 
+@class SPTSenTestCase;
+
 @interface SPTExample : NSObject {
   NSString *_name;
   id _block;
   BOOL _pending;
+  SPTSenTestCase *_testCase;
   BOOL _focused;
 }
 
 @property (nonatomic, copy) NSString *name;
 @property (nonatomic, copy) id block;
 @property (nonatomic) BOOL pending;
+@property (nonatomic, assign) SPTSenTestCase *testCase;
 @property (nonatomic, getter = isFocused) BOOL focused;
 
 - (id)initWithName:(NSString *)name block:(id)block;

--- a/src/SPTExample.m
+++ b/src/SPTExample.m
@@ -6,6 +6,7 @@
   name=_name
 , block=_block
 , pending=_pending
+, testCase=_testCase
 , focused=_focused
 ;
 

--- a/src/SPTSenTestCase.h
+++ b/src/SPTSenTestCase.h
@@ -28,4 +28,10 @@
 - (void)SPT_runExampleAtIndex:(NSUInteger)index;
 - (SPTExample *)SPT_getCurrentExample;
 
+// Called before each example begins.
+- (void)SPT_setUp;
+
+// Called after each example ends.
+- (void)SPT_tearDown;
+
 @end

--- a/src/SPTSenTestCase.m
+++ b/src/SPTSenTestCase.m
@@ -106,6 +106,7 @@
   SPTSpec *spec = [[self class] SPT_spec];
   spec.fileName = [NSString stringWithUTF8String:fileName];
   spec.lineNumber = lineNumber;
+  spec.testCase = self;
   [[[NSThread currentThread] threadDictionary] setObject:spec forKey:@"SPT_currentSpec"];
 }
 
@@ -139,6 +140,9 @@
   [self.SPT_invocation getArgument:&i atIndex:2];
   return [[[self class] SPT_spec].compiledExamples objectAtIndex:i];
 }
+
+- (void)SPT_setUp {}
+- (void)SPT_tearDown {}
 
 #pragma mark - SenTestCase overrides
 

--- a/src/SPTSpec.h
+++ b/src/SPTSpec.h
@@ -3,6 +3,7 @@
 @class
   SPTExample
 , SPTExampleGroup
+, SPTSenTestCase
 ;
 
 @interface SPTSpec : NSObject {
@@ -11,6 +12,7 @@
   NSArray *_compiledExamples;
   NSString *_fileName;
   NSUInteger _lineNumber;
+  SPTSenTestCase *_testCase;
   BOOL _hasFocusedExamples;
   BOOL _disabled;
 }
@@ -20,6 +22,7 @@
 @property (nonatomic, retain) NSArray *compiledExamples;
 @property (nonatomic, retain) NSString *fileName;
 @property (nonatomic) NSUInteger lineNumber;
+@property (nonatomic, retain) SPTSenTestCase *testCase;
 @property (nonatomic, getter = isDisabled) BOOL disabled;
 @property (nonatomic) BOOL hasFocusedExamples;
 

--- a/src/SPTSpec.m
+++ b/src/SPTSpec.m
@@ -10,6 +10,7 @@
 , compiledExamples=_compiledExamples
 , fileName=_fileName
 , lineNumber=_lineNumber
+, testCase=_testCase
 , disabled = _disabled
 , hasFocusedExamples = _hasFocusedExamples
 ;


### PR DESCRIPTION
These methods are similar to OCUnit's `-setUp` and `-tearDown`, which are run between every spec, except that the `SPT` versions are run between every example (e.g., each `it` or `itShouldBehaveLike` block).

This is useful for global set up/teardown work that needs to happen for all tests. For example, in GitHub for Mac, we use this opportunity to put clean repository fixtures into place for each test.

@joshaber 
