### PR TITLE
Declare blocks as blocks

### DIFF
--- a/src/Specta.h
+++ b/src/Specta.h
@@ -33,13 +33,13 @@ void    fdescribe(NSString *name, void (^block)());
 void      context(NSString *name, void (^block)());
 void     fcontext(NSString *name, void (^block)());
 
-void SPT_example(NSString *name, BOOL focused, id block);
-void     example(NSString *name, id block);
-void    fexample(NSString *name, id block);
-void          it(NSString *name, id block);
-void         fit(NSString *name, id block);
-void     specify(NSString *name, id block);
-void    fspecify(NSString *name, id block);
+void SPT_example(NSString *name, BOOL focused, void (^block)());
+void     example(NSString *name, void (^block)());
+void    fexample(NSString *name, void (^block)());
+void          it(NSString *name, void (^block)());
+void         fit(NSString *name, void (^block)());
+void     specify(NSString *name, void (^block)());
+void    fspecify(NSString *name, void (^block)());
 
 
 void SPT_pending(NSString *name, ...);
@@ -50,12 +50,12 @@ void SPT_pending(NSString *name, ...);
 #define  xspecify(...) SPT_pending(__VA_ARGS__, nil)
 #define   pending(...) SPT_pending(__VA_ARGS__, nil)
 
-void  beforeAll(id block);
-void   afterAll(id block);
-void beforeEach(id block);
-void  afterEach(id block);
-void     before(id block);
-void      after(id block);
+void  beforeAll(void (^block)());
+void   afterAll(void (^block)());
+void beforeEach(void (^block)());
+void  afterEach(void (^block)());
+void     before(void (^block)());
+void      after(void (^block)());
 
 void sharedExamplesFor(NSString *name, void (^block)(NSDictionary *data));
 void    sharedExamples(NSString *name, void (^block)(NSDictionary *data));

--- a/src/Specta.m
+++ b/src/Specta.m
@@ -43,32 +43,32 @@ void fcontext(NSString *name, void (^block)()) {
   SPT_describe(name, YES, block);
 }
 
-void SPT_example(NSString *name, BOOL focused, id block) {
+void SPT_example(NSString *name, BOOL focused, void (^block)()) {
   SPT_returnUnlessBlockOrNil(block);
   [SPT_currentGroup addExampleWithName:name block:block focused:focused];
 }
 
-void example(NSString *name, id block) {
+void example(NSString *name, void (^block)()) {
   SPT_example(name, NO, block);
 }
 
-void fexample(NSString *name, id block) {
+void fexample(NSString *name, void (^block)()) {
   SPT_example(name, YES, block);
 }
 
-void it(NSString *name, id block) {
+void it(NSString *name, void (^block)()) {
   SPT_example(name, NO, block);
 }
 
-void fit(NSString *name, id block) {
+void fit(NSString *name, void (^block)()) {
   SPT_example(name, YES, block);
 }
 
-void specify(NSString *name, id block) {
+void specify(NSString *name, void (^block)()) {
   SPT_example(name, NO, block);
 }
 
-void fspecify(NSString *name, id block) {
+void fspecify(NSString *name, void (^block)()) {
   SPT_example(name, YES, block);
 }
 
@@ -76,31 +76,31 @@ void SPT_pending(NSString *name, ...) {
   SPT_example(name, NO, nil);
 }
 
-void beforeAll(id block) {
+void beforeAll(void (^block)()) {
   SPT_returnUnlessBlockOrNil(block);
   [SPT_currentGroup addBeforeAllBlock:block];
 }
 
-void afterAll(id block) {
+void afterAll(void (^block)()) {
   SPT_returnUnlessBlockOrNil(block);
   [SPT_currentGroup addAfterAllBlock:block];
 }
 
-void beforeEach(id block) {
+void beforeEach(void (^block)()) {
   SPT_returnUnlessBlockOrNil(block);
   [SPT_currentGroup addBeforeEachBlock:block];
 }
 
-void afterEach(id block) {
+void afterEach(void (^block)()) {
   SPT_returnUnlessBlockOrNil(block);
   [SPT_currentGroup addAfterEachBlock:block];
 }
 
-void before(id block) {
+void before(void (^block)()) {
   beforeEach(block);
 }
 
-void after(id block) {
+void after(void (^block)()) {
   afterEach(block);
 }
 


### PR DESCRIPTION
By declaring blocks as actual blocks instead of objects typed to `id`, we get
much better code completion for free. Previously, if you hit enter in Xcode
with the block token selected, it would just insert `id block`, which isn't
super helpful. Now, if you hit enter on the block declaration, it expands the
token to the actual block declaration, drops to a new line, and selects a new
`code` token.
