### PR TITLE
Remove extra whitespace from the default template

### DIFF
--- a/templates/Specta/Specta Spec.xctemplate/Default/___FILEBASENAME___.m
+++ b/templates/Specta/Specta Spec.xctemplate/Default/___FILEBASENAME___.m
@@ -3,6 +3,4 @@ ___IMPORTHEADER_subjectClassName___
 
 SpecBegin(___VARIABLE_subjectClassName:identifier___)
 
-
-
 SpecEnd


### PR DESCRIPTION
The default template had a good deal of extra whitespace inside the spec
definition. I have removed it.
