### PR TITLE
Added capability to assign block results to keys for use inside examples...

### DIFF
--- a/Specta.xcodeproj/project.pbxproj
+++ b/Specta.xcodeproj/project.pbxproj
@@ -9,6 +9,10 @@
 /* Begin PBXBuildFile section */
 		372B8853169A31F0005FBE0C /* AsyncSpecTest.m in Sources */ = {isa = PBXBuildFile; fileRef = 372B8852169A31F0005FBE0C /* AsyncSpecTest.m */; };
 		372B8854169A31F0005FBE0C /* AsyncSpecTest.m in Sources */ = {isa = PBXBuildFile; fileRef = 372B8852169A31F0005FBE0C /* AsyncSpecTest.m */; };
+		8347E458180C369E00D2A422 /* AssignSpecTest.m in Sources */ = {isa = PBXBuildFile; fileRef = 8347E455180C369E00D2A422 /* AssignSpecTest.m */; };
+		8347E459180C369E00D2A422 /* AssignSpecTest.m in Sources */ = {isa = PBXBuildFile; fileRef = 8347E455180C369E00D2A422 /* AssignSpecTest.m */; };
+		8374A53D1811D4870041FDA3 /* AssignSpecTestNested.m in Sources */ = {isa = PBXBuildFile; fileRef = 8374A53C1811D4870041FDA3 /* AssignSpecTestNested.m */; };
+		8374A53E1811D4870041FDA3 /* AssignSpecTestNested.m in Sources */ = {isa = PBXBuildFile; fileRef = 8374A53C1811D4870041FDA3 /* AssignSpecTestNested.m */; };
 		CD564BEF17B09D83003942F5 /* CustomReporterTest.m in Sources */ = {isa = PBXBuildFile; fileRef = CD564BEE17B09D83003942F5 /* CustomReporterTest.m */; };
 		CD564BF017B09D83003942F5 /* CustomReporterTest.m in Sources */ = {isa = PBXBuildFile; fileRef = CD564BEE17B09D83003942F5 /* CustomReporterTest.m */; };
 		CDB75B34176E427900FF6631 /* SenTestLog+Specta.h in Headers */ = {isa = PBXBuildFile; fileRef = CDB75B32176E427900FF6631 /* SenTestLog+Specta.h */; settings = {ATTRIBUTES = (Private, ); }; };
@@ -172,6 +176,8 @@
 
 /* Begin PBXFileReference section */
 		372B8852169A31F0005FBE0C /* AsyncSpecTest.m */ = {isa = PBXFileReference; fileEncoding = 4; indentWidth = 2; lastKnownFileType = sourcecode.c.objc; path = AsyncSpecTest.m; sourceTree = "<group>"; tabWidth = 2; };
+		8347E455180C369E00D2A422 /* AssignSpecTest.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = AssignSpecTest.m; sourceTree = "<group>"; };
+		8374A53C1811D4870041FDA3 /* AssignSpecTestNested.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = AssignSpecTestNested.m; sourceTree = "<group>"; };
 		CD564BEE17B09D83003942F5 /* CustomReporterTest.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = CustomReporterTest.m; sourceTree = "<group>"; };
 		CDB75B32176E427900FF6631 /* SenTestLog+Specta.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "SenTestLog+Specta.h"; sourceTree = "<group>"; };
 		CDB75B33176E427900FF6631 /* SenTestLog+Specta.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = "SenTestLog+Specta.m"; sourceTree = "<group>"; };
@@ -378,6 +384,8 @@
 				E9D9422914B8B43200CD833A /* support */,
 				E9D9422C14B8B43200CD833A /* vendor */,
 				E9D9422514B8B43200CD833A /* helpers */,
+				8347E455180C369E00D2A422 /* AssignSpecTest.m */,
+				8374A53C1811D4870041FDA3 /* AssignSpecTestNested.m */,
 				E9D9421914B8B43200CD833A /* CompilationTest1.m */,
 				E9D9421A14B8B43200CD833A /* CompilationTest2.m */,
 				E9D9421B14B8B43200CD833A /* CompilationTest3.m */,
@@ -737,6 +745,7 @@
 			files = (
 				E96187B414C4AFA60021D7CE /* TestHelper.m in Sources */,
 				CD564BF017B09D83003942F5 /* CustomReporterTest.m in Sources */,
+				8374A53E1811D4870041FDA3 /* AssignSpecTestNested.m in Sources */,
 				E96187B514C4AFA60021D7CE /* CompilationTest1.m in Sources */,
 				E96187B614C4AFA60021D7CE /* CompilationTest2.m in Sources */,
 				E96187B714C4AFA60021D7CE /* CompilationTest3.m in Sources */,
@@ -753,6 +762,7 @@
 				E96187C114C4AFA60021D7CE /* DSLTest5.m in Sources */,
 				E96187C214C4AFA60021D7CE /* ReRunTest.m in Sources */,
 				E96187C314C4AFA70021D7CE /* SequenceTest.m in Sources */,
+				8347E459180C369E00D2A422 /* AssignSpecTest.m in Sources */,
 				E96187C414C4AFA70021D7CE /* PassingSpecTest.m in Sources */,
 				E96187C514C4AFA70021D7CE /* FailingSpecTest.m in Sources */,
 				E96187C614C4AFA70021D7CE /* UnexpectedExceptionTest.m in Sources */,
@@ -800,6 +810,7 @@
 			files = (
 				E9D9424814B8B43200CD833A /* CompilationTest1.m in Sources */,
 				CD564BEF17B09D83003942F5 /* CustomReporterTest.m in Sources */,
+				8374A53D1811D4870041FDA3 /* AssignSpecTestNested.m in Sources */,
 				E9D9424914B8B43200CD833A /* CompilationTest2.m in Sources */,
 				E9D9424A14B8B43200CD833A /* CompilationTest3.m in Sources */,
 				E9D9424B14B8B43200CD833A /* CompilationTest4.m in Sources */,
@@ -816,6 +827,7 @@
 				E9D9425514B8B43200CD833A /* SequenceTest.m in Sources */,
 				E910177314B911340087CD46 /* PassingSpecTest.m in Sources */,
 				E910177514B9114A0087CD46 /* FailingSpecTest.m in Sources */,
+				8347E458180C369E00D2A422 /* AssignSpecTest.m in Sources */,
 				E9B7778814BA24EC00D8DC76 /* TestHelper.m in Sources */,
 				E9BDBAB914BE2F3A00102FB5 /* MiscTest.m in Sources */,
 				E96598D914C345F3003BC25B /* CompilationTest8.m in Sources */,

--- a/src/SPTExample.h
+++ b/src/SPTExample.h
@@ -1,5 +1,6 @@
 #import <Foundation/Foundation.h>
 #import "SpectaTypes.h"
+#import "SPTExamplegroup.h"
 
 @interface SPTExample : NSObject {
   NSString *_name;
@@ -12,8 +13,9 @@
 @property (nonatomic, copy) id block;
 @property (nonatomic) BOOL pending;
 @property (nonatomic, getter = isFocused) BOOL focused;
+@property (nonatomic, retain) SPTExampleGroup *parentGroup;
 
-- (id)initWithName:(NSString *)name block:(id)block;
+- (id)initWithName:(NSString *)name block:(id)block parentGroup:(SPTExampleGroup *)parentGroup;
 
 @end
 

--- a/src/SPTExample.m
+++ b/src/SPTExample.m
@@ -7,6 +7,7 @@
 , block=_block
 , pending=_pending
 , focused=_focused
+, parentGroup=_parentGroup
 ;
 
 - (void)dealloc {
@@ -15,11 +16,12 @@
   [super dealloc];
 }
 
-- (id)initWithName:(NSString *)name block:(id)block {
+- (id)initWithName:(NSString *)name block:(id)block parentGroup:(SPTExampleGroup *)parentGroup {
   self = [super init];
   if(self) {
     self.name = name;
     self.block = block;
+    self.parentGroup = parentGroup;
     self.pending = block == nil;
   }
   return self;

--- a/src/SPTExampleGroup.h
+++ b/src/SPTExampleGroup.h
@@ -19,6 +19,7 @@
   unsigned int _exampleCount;
   unsigned int _ranExampleCount;
   BOOL _focused;
+  NSMutableDictionary *_assignments;
 }
 
 @property (nonatomic, copy) NSString *name;
@@ -33,6 +34,7 @@
 @property (nonatomic) unsigned int exampleCount;
 @property (nonatomic) unsigned int ranExampleCount;
 @property (nonatomic, getter=isFocused) BOOL focused;
+@property (nonatomic, retain) NSMutableDictionary *assignments;
 
 + (void)setAsyncSpecTimeout:(NSTimeInterval)timeout;
 - (id)initWithName:(NSString *)name parent:(SPTExampleGroup *)parent root:(SPTExampleGroup *)root;
@@ -42,6 +44,9 @@
 
 - (SPTExample *)addExampleWithName:(NSString *)name block:(id)block;
 - (SPTExample *)addExampleWithName:(NSString *)name block:(id)block focused:(BOOL)focused;
+
+- (void)assign:(NSString *)key forBlock:(id(^)())block;
+- (id)getAssign:(NSString *)key;
 
 - (void)addBeforeAllBlock:(SPTVoidBlock)block;
 - (void)addAfterAllBlock:(SPTVoidBlock)block;

--- a/src/SPTSpec.h
+++ b/src/SPTSpec.h
@@ -22,6 +22,7 @@
 @property (nonatomic) NSUInteger lineNumber;
 @property (nonatomic, getter = isDisabled) BOOL disabled;
 @property (nonatomic) BOOL hasFocusedExamples;
+@property (nonatomic, retain) SPTExample *currentExecutingExample;
 
 - (SPTExampleGroup *)currentGroup;
 - (void)compile;

--- a/src/SPTSpec.m
+++ b/src/SPTSpec.m
@@ -12,6 +12,7 @@
 , lineNumber=_lineNumber
 , disabled = _disabled
 , hasFocusedExamples = _hasFocusedExamples
+, currentExecutingExample=_currentExecutingExample
 ;
 
 - (void)dealloc {

--- a/src/Specta.h
+++ b/src/Specta.h
@@ -4,6 +4,7 @@
 #import "SPTSpec.h"
 #import "SPTExampleGroup.h"
 #import "SPTSharedExampleGroups.h"
+#import "SPTExample.h"
 #import "SenTestRun+Specta.h"
 
 @interface Specta : NSObject
@@ -56,6 +57,9 @@ void beforeEach(id block);
 void  afterEach(id block);
 void     before(id block);
 void      after(id block);
+
+void    assign(NSString *key, id (^block)());
+id   getAssign(NSString *key);
 
 void sharedExamplesFor(NSString *name, void (^block)(NSDictionary *data));
 void    sharedExamples(NSString *name, void (^block)(NSDictionary *data));

--- a/test/AssignSpecTest.m
+++ b/test/AssignSpecTest.m
@@ -1,0 +1,27 @@
+#import "TestHelper.h"
+
+SpecBegin(_AssignSpecTest)
+
+describe(@"assign", ^{
+    
+  assign(@"foo", ^{ return @"bar"; });
+    
+  it(@"accesses assgined block return value", ^{
+    NSString *foo = getAssign(@"foo");
+    expect(foo).toEqual(@"bar");
+  });
+
+});
+
+SpecEnd
+
+@interface AssignSpecTest : SenTestCase; @end
+@implementation AssignSpecTest
+
+- (void)testAssignSpec {
+  SenTestRun *result = RunSpec(_AssignSpecTestSpec);
+  expect([result failureCount]).toEqual(0);
+  expect([result hasSucceeded]).toEqual(YES);
+}
+
+@end

--- a/test/AssignSpecTestNested.m
+++ b/test/AssignSpecTestNested.m
@@ -1,0 +1,37 @@
+#import "TestHelper.h"
+
+SpecBegin(_AssignSpecTestNested)
+
+describe(@"outer assign", ^{
+    
+    assign(@"foo", ^{ return @"bar"; });
+    
+    describe(@"inner assign", ^{
+        
+        assign(@"foo", ^{ return @"baz"; });
+        
+        it(@"accesses inner assgined block return value", ^{
+            NSString *foo = getAssign(@"foo");
+            expect(foo).toEqual(@"baz");
+        });
+    });
+    
+    it(@"accesses outer assgined block return value", ^{
+        NSString *foo = getAssign(@"foo");
+        expect(foo).toEqual(@"bar");
+    });
+    
+});
+
+SpecEnd
+
+@interface AssignSpecTestNested : SenTestCase; @end
+@implementation AssignSpecTestNested
+
+- (void)testAssignNestedSpec {
+  SenTestRun *result = RunSpec(_AssignSpecTestNestedSpec);
+  expect([result failureCount]).toEqual(0);
+  expect([result hasSucceeded]).toEqual(YES);
+}
+
+@end


### PR DESCRIPTION
Please let me know if this feature is of interest.  In order to dry-up code across multiple examples, I added an `assign` function which takes a block and assigns its results to a key.  The result can then be re-accessed from within any example, or nested example group/example.  This is along the lines of RSPec's `let`.  

```
describe(@"assign", ^{

  assign(@"foo", ^{ return @"bar"; });

  it(@"accesses assgined block return value", ^{
    NSString *foo = getAssign(@"foo");
    expect(foo).toEqual(@"bar");
  });

});
```

If this is of interest, I can add block result memoization.

FYI.  In order to get this working, and especially with nesting, I had to:
- Add a reference to a parent ExampleGroup to Example
- Add a reference to the currently executing example to the Spec (SPT_getCurrentExample didn't seem to work).

Thanks
b
