### PR TITLE
Fix exception bubbling up

### DIFF
--- a/test/UnexpectedExceptionTest.m
+++ b/test/UnexpectedExceptionTest.m
@@ -56,7 +56,8 @@ SpecEnd
     expect(reason).toContain(@"UnexpectedExceptionTest");
   }
   expect([exception filename]).toContain(@"UnexpectedExceptionTest.m");
-  
+  shouldRaiseException = NO;
+
   expect(invokedAfterEach).toBeTruthy();
   expect(invokedAfterAll).toBeTruthy();
   


### PR DESCRIPTION
This addresses the exception @tonyarnold mentioned in #46 

```
/Users/tonyarnold/Documents/Open Source Projects/Specta/test/UnexpectedExceptionTest.m:0: error: -[_UnexpectedExceptionTestSpec group_example_1] : MyException: Oh Noes! %@
```

I did a bisect and tracked it down to 6e140532ede4557e5c01bab90d1856c6430ef087.

If I understand it correctly, if `shouldRaiseException` is not set back to `NO`, the `_UnexpectedExceptionTest` spec group is eventually executed again outside of `-testUnexpectedExceptionHandling` where the exception will then bubble up. This should fix that.
