### PR TITLE
Specta.m: raise when shared example does not exist

### DIFF
--- a/Specta.xcodeproj/project.pbxproj
+++ b/Specta.xcodeproj/project.pbxproj
@@ -31,6 +31,8 @@
 		CDF76B5D182617DB008BA160 /* XCTestRun+Specta.m in Sources */ = {isa = PBXBuildFile; fileRef = CDF76B59182617DB008BA160 /* XCTestRun+Specta.m */; };
 		DA2966A318DB180F0085E9C2 /* PendingSpecTest3.m in Sources */ = {isa = PBXBuildFile; fileRef = DA2966A218DB180F0085E9C2 /* PendingSpecTest3.m */; };
 		DA2966A418DB21FF0085E9C2 /* PendingSpecTest3.m in Sources */ = {isa = PBXBuildFile; fileRef = DA2966A218DB180F0085E9C2 /* PendingSpecTest3.m */; };
+		DA472DEE1934C37800E15A8E /* SharedExamplesTest6.m in Sources */ = {isa = PBXBuildFile; fileRef = DA472DED1934C37800E15A8E /* SharedExamplesTest6.m */; };
+		DA472DEF1934C38400E15A8E /* SharedExamplesTest6.m in Sources */ = {isa = PBXBuildFile; fileRef = DA472DED1934C37800E15A8E /* SharedExamplesTest6.m */; };
 		E93B45A318205B91009F43A2 /* Specta.m in Sources */ = {isa = PBXBuildFile; fileRef = E9901C5218205B6600844A05 /* Specta.m */; };
 		E93B45A418205B91009F43A2 /* SpectaUtility.m in Sources */ = {isa = PBXBuildFile; fileRef = E9901C5618205B6600844A05 /* SpectaUtility.m */; };
 		E93B45A518205B91009F43A2 /* SPTExample.m in Sources */ = {isa = PBXBuildFile; fileRef = E9901C5818205B6600844A05 /* SPTExample.m */; };
@@ -175,6 +177,7 @@
 		CDF76B58182617DB008BA160 /* XCTestRun+Specta.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "XCTestRun+Specta.h"; sourceTree = "<group>"; };
 		CDF76B59182617DB008BA160 /* XCTestRun+Specta.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = "XCTestRun+Specta.m"; sourceTree = "<group>"; };
 		DA2966A218DB180F0085E9C2 /* PendingSpecTest3.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = PendingSpecTest3.m; sourceTree = "<group>"; };
+		DA472DED1934C37800E15A8E /* SharedExamplesTest6.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = SharedExamplesTest6.m; sourceTree = "<group>"; };
 		E93B45D018205C2B009F43A2 /* Foundation.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Foundation.framework; path = Platforms/MacOSX.platform/Developer/SDKs/MacOSX10.9.sdk/System/Library/Frameworks/Foundation.framework; sourceTree = DEVELOPER_DIR; };
 		E93B45D318205C77009F43A2 /* AsyncSpecTest.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = AsyncSpecTest.m; sourceTree = "<group>"; };
 		E93B45D418205C77009F43A2 /* AsyncSpecTest2.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = AsyncSpecTest2.m; sourceTree = "<group>"; };
@@ -340,6 +343,7 @@
 				E93B45F718205C77009F43A2 /* SpectaUtilityTest.m */,
 				E93B45FA18205C77009F43A2 /* UnexpectedExceptionTest.m */,
 				B91EE39C18A0F41B0074E17C /* MultipleTestObserverTest.m */,
+				DA472DED1934C37800E15A8E /* SharedExamplesTest6.m */,
 			);
 			path = test;
 			sourceTree = "<group>";
@@ -659,6 +663,7 @@
 				E93B463318205C9E009F43A2 /* FocusedSpecTest.m in Sources */,
 				E93B462A18205C9E009F43A2 /* CompilationTest6.m in Sources */,
 				E93B462E18205C9E009F43A2 /* DSLTest2.m in Sources */,
+				DA472DEE1934C37800E15A8E /* SharedExamplesTest6.m in Sources */,
 				E93B462B18205C9E009F43A2 /* CompilationTest7.m in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -722,6 +727,7 @@
 				E93B461218205C9E009F43A2 /* FocusedSpecTest.m in Sources */,
 				E93B460918205C9E009F43A2 /* CompilationTest6.m in Sources */,
 				E93B460D18205C9E009F43A2 /* DSLTest2.m in Sources */,
+				DA472DEF1934C38400E15A8E /* SharedExamplesTest6.m in Sources */,
 				E93B460A18205C9E009F43A2 /* CompilationTest7.m in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/src/Specta.m
+++ b/src/Specta.m
@@ -133,7 +133,7 @@ void SPTitShouldBehaveLike(const char *fileName, NSUInteger lineNumber, NSString
       [currentTestCase recordFailureWithDescription:@"itShouldBehaveLike should not be invoked inside an example block!" inFile:@(fileName) atLine:lineNumber expected:NO];
     } else {
       it(name, ^{
-        [currentTestCase recordFailureWithDescription:[NSString stringWithFormat:@"Shared example group \"%@\" does not exist.", name] inFile:@(fileName) atLine:lineNumber expected:NO];
+        [SPTCurrentTestCase recordFailureWithDescription:[NSString stringWithFormat:@"Shared example group \"%@\" does not exist.", name] inFile:@(fileName) atLine:lineNumber expected:NO];
       });
     }
   }

--- a/test/SharedExamplesTest6.m
+++ b/test/SharedExamplesTest6.m
@@ -1,0 +1,31 @@
+#import "TestHelper.h"
+
+// We expect the `itBehavesLike` example to fail.
+// Use this flag to ensure the example is only
+// run during the test case below.
+static BOOL shouldInvokeItBehavesLike = NO;
+
+SpecBegin(_SharedExamplesTest6)
+
+it(@"fails", ^{
+  if (shouldInvokeItBehavesLike) {
+    itBehavesLike(@"a set of shared examples that don't exist", nil);
+  }
+});
+
+SpecEnd
+
+@interface SharedExamplesTest6 : XCTestCase; @end
+@implementation SharedExamplesTest6
+
+- (void)testSharedExamplesFailingIfNonexistent {
+  shouldInvokeItBehavesLike = YES;
+  XCTestSuiteRun *result = RunSpec(_SharedExamplesTest6Spec);
+  SPTAssertEqual([result testCaseCount], 1);
+  SPTAssertEqual([result unexpectedExceptionCount], 1);
+  SPTAssertEqual([result failureCount], 0);
+  SPTAssertFalse([result hasSucceeded]);
+  shouldInvokeItBehavesLike = NO;
+}
+
+@end


### PR DESCRIPTION
Shared examples do not fail when the specified shared example group is
not defined. The original, intended behavior in case a user tried to use
an undefined shared example group was to raise an exception. [1] This
behavior was broken during the migration from SenTestingKit to XCTest. [2]
The regression was caused by a failure to "re-evaluate"
SPTCurrentTestCase, which is nil in some cases.
- Re-evaluate SPTCurrentTestCase within an it block in order to inform
  the XCTest harness of a test failure.
- Add SharedExamplesTest6 to prevent future regressions.

Fixes issue #68.

[1] https://github.com/specta/specta/commit/db0ec3d7#diff-5f0b31e53d8721b15d8afed4265ce1caR138
[2] https://github.com/specta/specta/commit/725ba21b#diff-5f0b31e53d8721b15d8afed4265ce1caR136
