### PR TITLE
Fix OCMock 3 incompatibility by adding required protocol for global beforeEach/afterEach

### DIFF
--- a/Specta.xcodeproj/project.pbxproj
+++ b/Specta.xcodeproj/project.pbxproj
@@ -163,6 +163,7 @@
 /* End PBXContainerItemProxy section */
 
 /* Begin PBXFileReference section */
+		510C2478195081610071224C /* SPTGlobalBeforeAfterEach.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = SPTGlobalBeforeAfterEach.h; sourceTree = "<group>"; };
 		B91EE39C18A0F41B0074E17C /* MultipleTestObserverTest.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = MultipleTestObserverTest.m; sourceTree = "<group>"; };
 		CD7723671825A67A00719E93 /* SPTReporter.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = SPTReporter.h; sourceTree = "<group>"; };
 		CD7723681825A67A00719E93 /* SPTReporter.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = SPTReporter.m; sourceTree = "<group>"; };
@@ -429,6 +430,7 @@
 				CDF76B5318260AA5008BA160 /* SPTXCTestReporter.m */,
 				CDF76B4C1825C8B1008BA160 /* SPTNestedReporter.h */,
 				CDF76B4D1825C8B1008BA160 /* SPTNestedReporter.m */,
+				510C2478195081610071224C /* SPTGlobalBeforeAfterEach.h */,
 			);
 			path = src;
 			sourceTree = "<group>";

--- a/src/SPTGlobalBeforeAfterEach.h
+++ b/src/SPTGlobalBeforeAfterEach.h
@@ -1,0 +1,9 @@
+#import <Foundation/Foundation.h>
+
+@protocol SPTGlobalBeforeAfterEach <NSObject>
+
+@required
++ (void)beforeEach;
++ (void)afterEach;
+
+@end

--- a/src/Specta.h
+++ b/src/Specta.h
@@ -5,6 +5,7 @@
 #import "SPTSpec.h"
 #import "SPTExampleGroup.h"
 #import "SPTSharedExampleGroups.h"
+#import "SPTGlobalBeforeAfterEach.h"
 
 @interface Specta : NSObject
 @end

--- a/test/SequenceTest.m
+++ b/test/SequenceTest.m
@@ -2,7 +2,7 @@
 
 static NSMutableArray *sequence = nil;
 
-@interface SequenceTestHelper : NSObject
+@interface SequenceTestHelper : NSObject <SPTGlobalBeforeAfterEach>
 @end
 
 @implementation SequenceTestHelper
@@ -13,6 +13,27 @@ static NSMutableArray *sequence = nil;
 
 + (void)afterEach {
   [sequence addObject:@"+afterEach"];
+}
+
+@end
+
+// This class should not have its +beforeEach and +afterEach methods run, because it does not
+// conform to SPTGlobalBeforeAfterEach
+@interface FakeGlobalBeforeAfterEach : NSObject
+
++ (void)beforeEach;
++ (void)afterEach;
+
+@end
+
+@implementation FakeGlobalBeforeAfterEach
+
++ (void)beforeEach {
+  [sequence addObject:@"+beforeEach (should not run)"];
+}
+
++ (void)afterEach {
+  [sequence addObject:@"+afterEach (should not run)"];
 }
 
 @end


### PR DESCRIPTION
#21 introduced functionality to run `+beforeEach` or `+afterEach` methods from any class around every example in the test target. This causes crashes when stubbing class methods with OCMock 3, because the `ClassesWithClassMethod` function in `SPTExampleGroup.m` looks for those methods on OCMock's stubbed classes before they are properly set up.

I've looked at several ways to fix the incompatibility (from the OCMock side as well as Specta), but this one seems like the best approach: instead of looking for `+beforeEach` or `+afterEach` on _any_ class, Specta will look for classes that conform to a new protocol: `SPTGlobalBeforeAfterEach`. It probably should have been implemented this way from the start:
* Adding the protocol signals the programmer's intent more clearly and makes it marginally easier to find these classes.
* While the chances of having non-test-related methods named `+beforeEach` or `+afterEach` are low, it can certainly happen. There is already a special case to avoid the `UIAccessibilitySafeCategory__NSObject` class, and using a protocol makes that unnecessary.

This is a backwards-incompatible change, but the fix is extremely easy. On any class that has these methods,

```objective-c
@interface SomeSharedTestSetup : NSObject
+ (void)beforeEach;
+ (void)afterEach;
@end
```

just add the protocol to the interface declaration:

```objective-c
@interface SomeSharedTestSetup : NSObject <SPTGlobalBeforeAfterEach>
+ (void)beforeEach;
+ (void)afterEach;
@end
```
