### PR TITLE
Update podspec source_files to point to Specta folder instead of src

### DIFF
--- a/Specta.podspec
+++ b/Specta.podspec
@@ -16,7 +16,7 @@ Pod::Spec.new do |s|
     framework. Expecta and OCMock are recommended.
   }
 
-  s.source_files = 'src/**/*.{h,m}'
+  s.source_files = 'Specta/**/*.{h,m}'
 
   s.frameworks = 'Foundation', 'XCTest'
 


### PR DESCRIPTION
Since things got rearranged in f9aacb29bd75b22cd91f0d6497b417f810ee9b96, the podspec is no longer valid.
