### PR TITLE
Remove redefinition of _XCTRegisterFailure.

### DIFF
--- a/src/SpectaSupport.h
+++ b/src/SpectaSupport.h
@@ -39,8 +39,3 @@
 } \
 @end
 
-#undef _XCTRegisterFailure
-#define _XCTRegisterFailure(condition, format...) \
-({ \
-_XCTFailureHandler((id)self, YES, __FILE__, __LINE__, condition, @"" format); \
-})


### PR DESCRIPTION
It breaks usage of `XCTFail()` in Xcode 6 and taking it out seems to have no visible impact. It also seems extremely brittle to randomly change XCTest internals.
