### PR TITLE
Restored custom base class functionality

### DIFF
--- a/README.md
+++ b/README.md
@@ -154,6 +154,14 @@ SpecEnd
 
 * Use Facebook's [xctool](https://github.com/facebook/xctool/).
 
+## INJECTING A CUSTOM BASE SPEC CLASS
+
+The base class for all specs is `SPTSpec`. If you would like to use your own base class, for example to inject a global `setUp`/`tearDown` behavior, your base class should extend `SPTSpec`.
+
+In the precompiled header for your test target, define the SPT_SUBCLASS macro to point to your base class (in this case `MyBaseSpec`)
+
+    #define SPT_SUBCLASS MyBaseSpec
+
 ## CONTRIBUTION GUIDELINES
 
 * Please use only spaces and indent 2 spaces at a time.

--- a/Specta/Specta/SpectaDSL.h
+++ b/Specta/Specta/SpectaDSL.h
@@ -53,8 +53,12 @@ void setAsyncSpecTimeout(NSTimeInterval timeout);
 
 // ----------------------------------------------------------------------------
 
+#ifndef SPT_SUBCLASS
+#define SPT_SUBCLASS SPTSpec
+#endif
+
 #define _SPTSpecBegin(name, file, line) \
-@interface name##Spec : SPTSpec \
+@interface name##Spec : SPT_SUBCLASS \
 @end \
 @implementation name##Spec \
 - (void)spec { \


### PR DESCRIPTION
This was removed in https://github.com/specta/specta/commit/e91c0f8a51df6158413efe4ac3582c8fe9e442e7. I've tested it in our own project, where we used it in Xcode 5, and it's working fine again with this change.