### PR TITLE
Attempt to fix OCMock 3 incompatibility

### DIFF
--- a/Specta/Specta.xcodeproj/project.pbxproj
+++ b/Specta/Specta.xcodeproj/project.pbxproj
@@ -7,6 +7,7 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		B27A96FD931E25BE3F7E615E /* SPTExcludeGlobalBeforeAfterEach.h in Headers */ = {isa = PBXBuildFile; fileRef = B27A9A666AF7370DC4D7F211 /* SPTExcludeGlobalBeforeAfterEach.h */; };
 		E917141D19DF0A3100921712 /* SpectaDSL.m in Sources */ = {isa = PBXBuildFile; fileRef = E963AB9B1968E13800A592DF /* SpectaDSL.m */; };
 		E917141E19DF0A3100921712 /* SpectaDSL.m in Sources */ = {isa = PBXBuildFile; fileRef = E963AB9B1968E13800A592DF /* SpectaDSL.m */; };
 		E917141F19DF0A3500921712 /* SpectaUtility.m in Sources */ = {isa = PBXBuildFile; fileRef = E963AB9E1968E13800A592DF /* SpectaUtility.m */; };
@@ -260,6 +261,7 @@
 /* End PBXContainerItemProxy section */
 
 /* Begin PBXFileReference section */
+		B27A9A666AF7370DC4D7F211 /* SPTExcludeGlobalBeforeAfterEach.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = SPTExcludeGlobalBeforeAfterEach.h; sourceTree = "<group>"; };
 		E91713F119DF07BB00921712 /* libSpecta.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = libSpecta.a; sourceTree = BUILT_PRODUCTS_DIR; };
 		E917140919DF07D700921712 /* libSpecta.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = libSpecta.a; sourceTree = BUILT_PRODUCTS_DIR; };
 		E9288BE619BE182900DE96FA /* XCTest.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = XCTest.framework; path = Platforms/MacOSX.platform/Developer/Library/Frameworks/XCTest.framework; sourceTree = DEVELOPER_DIR; };
@@ -435,6 +437,7 @@
 				E963ABAD1968E13800A592DF /* XCTest+Private.h */,
 				E963ABAE1968E13800A592DF /* XCTestCase+Specta.h */,
 				E963ABAF1968E13800A592DF /* XCTestCase+Specta.m */,
+				B27A9A666AF7370DC4D7F211 /* SPTExcludeGlobalBeforeAfterEach.h */,
 			);
 			path = Specta;
 			sourceTree = "<group>";
@@ -544,6 +547,7 @@
 				E963ABC41968E13800A592DF /* SPTCompiledExample.h in Headers */,
 				E963ABB41968E13800A592DF /* Specta.h in Headers */,
 				E963ABBA1968E13800A592DF /* SpectaTypes.h in Headers */,
+				B27A96FD931E25BE3F7E615E /* SPTExcludeGlobalBeforeAfterEach.h in Headers */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/Specta/Specta/SPTExampleGroup.m
+++ b/Specta/Specta/SPTExampleGroup.m
@@ -24,6 +24,14 @@ static NSArray *ClassesWithClassMethod(SEL classMethodSelector) {
       Class aClass = classes[classIndex];
 
       if (class_conformsToProtocol(aClass, @protocol(SPTExcludeGlobalBeforeAfterEach)) == NO) {
+        // If you're seeing a crash here then your probably have to blacklist crashing class from global before/after hooks.
+        // Specta supports blacklisting specific Classes from being treated as before/after helper classes
+        // to add an new class to the list add the following lines to a project initialiser ( e.g. App Delegate callbacks )
+        //
+        //  Class myClass = NSClassFromString(@"MyClass");
+        //  class_addProtocol(myClass, @protocol(SPTExcludeGlobalBeforeAfterEach));
+        //
+        //  You can also create a category for that class which implements SPTExcludeGlobalBeforeAfterEach.
         Method globalMethod = class_getClassMethod(aClass, classMethodSelector);
         if (globalMethod) {
           [classesWithClassMethod addObject:aClass];

--- a/Specta/Specta/SPTExampleGroup.m
+++ b/Specta/Specta/SPTExampleGroup.m
@@ -4,11 +4,16 @@
 #import "SPTSpec.h"
 #import "SpectaUtility.h"
 #import "XCTest+Private.h"
+#import "SPTExcludeGlobalBeforeAfterEach.h"
 #import <libkern/OSAtomic.h>
 #import <objc/runtime.h>
 
 static NSArray *ClassesWithClassMethod(SEL classMethodSelector) {
   NSMutableArray *classesWithClassMethod = [[NSMutableArray alloc] init];
+
+  //TODO: need a better place for this
+  Class accessbilitySafeCategoryClass = NSClassFromString(@"UIAccessibilitySafeCategory__NSObject");
+  class_addProtocol(accessbilitySafeCategoryClass, @protocol(SPTExcludeGlobalBeforeAfterEach));
 
   int numberOfClasses = objc_getClassList(NULL, 0);
   if (numberOfClasses > 0) {
@@ -18,7 +23,7 @@ static NSArray *ClassesWithClassMethod(SEL classMethodSelector) {
     for(int classIndex = 0; classIndex < numberOfClasses; classIndex++) {
       Class aClass = classes[classIndex];
 
-      if (strcmp("UIAccessibilitySafeCategory__NSObject", class_getName(aClass))) {
+      if (class_conformsToProtocol(aClass, @protocol(SPTExcludeGlobalBeforeAfterEach)) == NO) {
         Method globalMethod = class_getClassMethod(aClass, classMethodSelector);
         if (globalMethod) {
           [classesWithClassMethod addObject:aClass];

--- a/Specta/Specta/SPTExcludeGlobalBeforeAfterEach.h
+++ b/Specta/Specta/SPTExcludeGlobalBeforeAfterEach.h
@@ -1,0 +1,10 @@
+/*
+ * Copyright (c) 2015 Specta Team. All rights reserved.
+ */
+#import <Foundation/Foundation.h>
+
+// This protocol is used for blacklisting classes for global beforeEach and afterEach blocks.
+// If you do not want a class to participate in those just add this protocol to a category and it will be
+// excluded.
+@protocol SPTExcludeGlobalBeforeAfterEach <NSObject>
+@end


### PR DESCRIPTION
This PR takes a little bit different approach than https://github.com/specta/specta/pull/86. Rather than whitelisting specific classes via protocol I've added a protocol that allows blacklisting of certain classes. From what I can tell the OCMock issue can be fixed by creating a category that adds the protocol to `OCMockObject`. Same goes for Google Analytics https://github.com/specta/specta/issues/116. 

There is one thing that I really don't like but I currently have no better idea, which is where to place code that adds this protocol to our beloved `UIAccessibilitySafeCategory__NSObject`. Ideas are welcomed. 