### PR TITLE
Ensure failures are delivered on the main thread

### DIFF
--- a/Specta/SpectaTests/AsyncSpecTest.m
+++ b/Specta/SpectaTests/AsyncSpecTest.m
@@ -34,6 +34,15 @@ describe(@"group", ^{
       });
     });
   });
+
+  it(@"assert on background queue", ^{
+    waitUntil(^(DoneCallback done) {
+      dispatch_async(dispatch_get_global_queue(DISPATCH_QUEUE_PRIORITY_DEFAULT, 0), ^{
+        assertEqualObjects(foo, @"foo");
+        done();
+      });
+    });
+  });
 });
 
 SpecEnd
@@ -46,7 +55,7 @@ SpecEnd
   bar = @"not bar";
   XCTestRun *result = RunSpec(_AsyncSpecTestSpec);
   assertEqual([result unexpectedExceptionCount], 0);
-  assertEqual([result failureCount], 2);
+  assertEqual([result failureCount], 3);
   assertFalse([result hasSucceeded]);
   foo = @"foo";
   bar = @"bar";


### PR DESCRIPTION
`-[XCTestCase _dequeueFailures]` will only process failures if it is called from the main thread. If an asynchronous test makes assertions on another thread, that will not be the case, leading to masked failures. This PR implements a workaround by swizzling the method and calling the original method on the main thread if called from another thread. It also provides a spec for assertions on a background queue.

This should fix #123, #96 and possibly #44 - note that the descriptions of the problem in most of those issues are out of date, because of the implementation changes regarding asynchronous testing.