### PR TITLE
Fix for reporting specta/expecta failures on the main thread.

### DIFF
--- a/Specta/Specta/SpectaUtility.h
+++ b/Specta/Specta/SpectaUtility.h
@@ -3,8 +3,8 @@
 extern NSString * const spt_kCurrentTestSuiteKey;
 extern NSString * const spt_kCurrentSpecKey;
 
-#define SPTCurrentTestSuite [[NSThread currentThread] threadDictionary][spt_kCurrentTestSuiteKey]
-#define SPTCurrentSpec  [[NSThread currentThread] threadDictionary][spt_kCurrentSpecKey]
+#define SPTCurrentTestSuite [[NSThread mainThread] threadDictionary][spt_kCurrentTestSuiteKey]
+#define SPTCurrentSpec  [[NSThread mainThread] threadDictionary][spt_kCurrentSpecKey]
 #define SPTCurrentGroup     [SPTCurrentTestSuite currentGroup]
 #define SPTGroupStack       [SPTCurrentTestSuite groupStack]
 


### PR DESCRIPTION
I had originally tried to fix code within Expecta (https://github.com/specta/expecta/blob/master/Expecta/ExpectaSupport.m#L165) by using mainThread instead of currentThread. However this did not work for me in the current code base.

I was able to fix my multithreaded error reporting using these macro definitions.