### PR TITLE
Run Xcode command line tools with xcrun

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -14,11 +14,11 @@ def execute(command, stdout=nil)
 end
 
 def test(scheme)
-  execute "xcodebuild -workspace #{WORKSPACE} -scheme #{scheme} -configuration #{CONFIGURATION} test SYMROOT=build | xcpretty -c && exit ${PIPESTATUS[0]}"
+  execute "xcrun xcodebuild -workspace #{WORKSPACE} -scheme #{scheme} -configuration #{CONFIGURATION} test SYMROOT=build | xcpretty -c && exit ${PIPESTATUS[0]}"
 end
 
 def build(scheme, sdk, product)
-  execute "xcodebuild -workspace #{WORKSPACE} -scheme #{scheme} -sdk #{sdk} -configuration #{CONFIGURATION} SYMROOT=build"
+  execute "xcrun xcodebuild -workspace #{WORKSPACE} -scheme #{scheme} -sdk #{sdk} -configuration #{CONFIGURATION} SYMROOT=build"
   build_dir = "#{CONFIGURATION}#{sdk == 'macosx' ? '' : "-#{sdk}"}"
   "Specta/build/#{build_dir}/#{product}"
 end
@@ -32,11 +32,11 @@ def build_static_lib(scheme, sdk)
 end
 
 def lipo(bin1, bin2, output)
-  execute "lipo -create '#{bin1}' '#{bin2}' -output '#{output}'"
+  execute "xcrun lipo -create '#{bin1}' '#{bin2}' -output '#{output}'"
 end
 
 def clean(scheme)
-  execute "xcodebuild -workspace #{WORKSPACE} -scheme #{scheme} clean"
+  execute "xcrun xcodebuild -workspace #{WORKSPACE} -scheme #{scheme} clean"
 end
 
 def puts_green(str)
@@ -45,7 +45,7 @@ end
 
 desc 'Run tests'
 task :test do |t|
-  execute "xcodebuild test -workspace Specta.xcworkspace -scheme Specta"
+  execute "xcrun xcodebuild test -workspace Specta.xcworkspace -scheme Specta"
 end
 
 desc 'clean'
@@ -86,7 +86,7 @@ task :build => :clean do |t|
   lipo(ios_static_lib, ios_sim_static_lib, ios_univ_static_lib)
 
   puts_green "\n=== CODESIGN iOS FRAMEWORK ==="
-  execute "/usr/bin/codesign --force --sign 'iPhone Developer' --resource-rules='#{ios_univ_framework}'/ResourceRules.plist '#{ios_univ_framework}'"
+  execute "xcrun codesign --force --sign 'iPhone Developer' --resource-rules='#{ios_univ_framework}'/ResourceRules.plist '#{ios_univ_framework}'"
 
   puts_green "\n=== COPY PRODUCTS ==="
   execute "yes | rm -rf Products"


### PR DESCRIPTION
### Motivation

I work in an environment where I use multiple versions of Xcode.  I often use the `DEVELOPER_DIR` to control which version of Xcode I am using on a per-command basis.

Using `xcrun` to locate the active Xcode command-line tools is a good practice.  It can also help to quickly confirm that a behavior works as expected across Xcode versions.

#### Examples

```
$ cd specta
$ DEVELOPER_DIR=/Xcode/5.1.1/Xcode.app rake test
$ DEVELOPER_DIR=/Xcode/6.1.1/Xcode.app rake test
$ DEVELOPER_DIR=/Xcode/6.2/Xcode-Beta.app rake test
$ DEVELOPER_DIR=/Xcode/6.3/Xcode-Beta.app rake test
```

#### $ man xcrun

```
DEVELOPER_DIR
          Overrides the active developer directory. When DEVELOPER_DIR
          is set, its value will be used instead  of  the  system-wide
          active developer directory.
```