### PR TITLE
Add ENV var to control signing identity in rake build task

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -35,6 +35,10 @@ def lipo(bin1, bin2, output)
   execute "xcrun lipo -create '#{bin1}' '#{bin2}' -output '#{output}'"
 end
 
+def code_signing_identity
+  ENV['SPT_CODE_SIGNING_IDENTITY'] || 'iPhone Developer'
+end
+
 def clean(scheme)
   execute "xcrun xcodebuild -workspace #{WORKSPACE} -scheme #{scheme} clean"
 end
@@ -86,7 +90,7 @@ task :build => :clean do |t|
   lipo(ios_static_lib, ios_sim_static_lib, ios_univ_static_lib)
 
   puts_green "\n=== CODESIGN iOS FRAMEWORK ==="
-  execute "xcrun codesign --force --sign 'iPhone Developer' --resource-rules='#{ios_univ_framework}'/ResourceRules.plist '#{ios_univ_framework}'"
+  execute "xcrun codesign --force --sign \"#{code_signing_identity}\" --resource-rules='#{ios_univ_framework}'/ResourceRules.plist '#{ios_univ_framework}'"
 
   puts_green "\n=== COPY PRODUCTS ==="
   execute "yes | rm -rf Products"


### PR DESCRIPTION
**FORCE PUSHED** Tue Mar 3 14:24 CET

### Motivation

I am blessed or cursed (take your pick) with many code-signing identities.

The `$ rake` command fails for me out of the box.

#### Examples

```
# Two developer identities
Running /usr/bin/codesign <snip>
Warning: --resource-rules has been deprecated in Mac OS X >= 10.10!
iPhone: ambiguous (matches "iPhone Developer: My Identity (9<snip>L)" and
                           "iPhone Developer: Some Client (8<snip>Z)" 
                  in /<snip>/login.keychain)
rake aborted!
** BUILD FAILED **


# I don't know why codesign matched this distribution identity
# when it was passed "iPhone Developer"
Running /usr/bin/codesign <snip>
Warning: --resource-rules has been deprecated in Mac OS X >= 10.10!
iPhone: ambiguous (matches "iPhone Distribution: XXXXX" and 
                           "iPhone Developer: Some Client (8<snip>Z)" 
                   in /<snip>/login.keychain)
rake aborted!
** BUILD FAILED **
```

I don't have a great way of handling this in open-source projects.  One way is to use an environment variable to control the code-signing identity.

```
$ SPT_CODE_SIGNING_IDENTITY="iPhone Developer: Some Client (8<snip>Z)" rake
```

Since user like me are in the minority and usually savvy enough to know why a `codesign` command fails with ambiguous matches, giving them a command-line variable to control the identity seems mostly harmless.

In the absence of the `SPT_CODE_SIGNING_IDENTITY` the `$ rake` command behaves as before.  If the new environment variable is malformed or incorrect, `codesign` will log a meaningful message:

```
$ SPT_CODE_SIGNING_IDENTITY="iPhone Developer: No Such Developer (8<snip>X)" rake
...
iPhone Developer: No Such Developer (8<snip>X): no identity found
...