### PR TITLE
Add a contributing doc

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,13 @@
+## GETTING HELP
+
+Please reserve the GitHub issues for feature requests and bug reports.
+
+Ask questions and get answers on Stack Overflow using the `specta` tag.
+
+* http://stackoverflow.com/questions/tagged/specta
+
+## CONTRIBUTION GUIDELINES
+
+* Please use only spaces and indent 2 spaces at a time.
+* Please prefix instance variable names with a single underscore (`_`).
+* Please prefix custom classes and functions defined in the global scope with `SPT`.


### PR DESCRIPTION
### Motivation

I maintain several open source projects.  I really don't like it when users ask questions in GitHub issues. 

 I had a question today about Specta:  **Defining a variable that can be used across all examples in a group: like `let`** #137.  I felt genuinely terrible asking in a GitHub issue, but I didn't see any documentation that mentioned I should ask my question on Stack Overflow.

This PR adds a CONTRIBUTING.md doc that directs users to Stack Overflow.

I really like cucumber's [CONTRIBUTING.md document](https://github.com/cucumber/cucumber/blob/master/CONTRIBUTING.md).  

Maybe the wiki home page could point people with questions to Stack Overflow as well?
