### PR TITLE
Fix typo in CHANGELOG for version 0.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 v0.4
 ======
-* Makes it easy to skip the beforeAll/afterAll functions for specific classes
+* Makes it easy to skip the beforeEach/afterEach functions for specific classes
 * All failures now call back on the main thread [neonacho + J-Rojas]
 * ENV var to control signing [jmoody]
 * Run Xcode command line tools with xcrun [jmoody]


### PR DESCRIPTION
> Makes it easy to skip the beforeAll/afterAll functions for specific classes

The `SPTExcludeGlobalBeforeAfterEach` exlcludes `+ beforeEach` and `+ afterEach` implemented by the classes that conform to it. There's no global beforeAll/aftreAll (yet?).