### PR TITLE
Increment the ran test cases number for pending 

### DIFF
--- a/Specta/Specta.xcodeproj/project.pbxproj
+++ b/Specta/Specta.xcodeproj/project.pbxproj
@@ -8,6 +8,8 @@
 
 /* Begin PBXBuildFile section */
 		B27A96FD931E25BE3F7E615E /* SPTExcludeGlobalBeforeAfterEach.h in Headers */ = {isa = PBXBuildFile; fileRef = B27A9A666AF7370DC4D7F211 /* SPTExcludeGlobalBeforeAfterEach.h */; };
+		D0D022261AB8B983000DC090 /* PendingSpecTest5.m in Sources */ = {isa = PBXBuildFile; fileRef = D0D022251AB8B983000DC090 /* PendingSpecTest5.m */; };
+		D0D022271AB8B983000DC090 /* PendingSpecTest5.m in Sources */ = {isa = PBXBuildFile; fileRef = D0D022251AB8B983000DC090 /* PendingSpecTest5.m */; };
 		E917141D19DF0A3100921712 /* SpectaDSL.m in Sources */ = {isa = PBXBuildFile; fileRef = E963AB9B1968E13800A592DF /* SpectaDSL.m */; };
 		E917141E19DF0A3100921712 /* SpectaDSL.m in Sources */ = {isa = PBXBuildFile; fileRef = E963AB9B1968E13800A592DF /* SpectaDSL.m */; };
 		E917141F19DF0A3500921712 /* SpectaUtility.m in Sources */ = {isa = PBXBuildFile; fileRef = E963AB9E1968E13800A592DF /* SpectaUtility.m */; };
@@ -262,6 +264,7 @@
 
 /* Begin PBXFileReference section */
 		B27A9A666AF7370DC4D7F211 /* SPTExcludeGlobalBeforeAfterEach.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = SPTExcludeGlobalBeforeAfterEach.h; sourceTree = "<group>"; };
+		D0D022251AB8B983000DC090 /* PendingSpecTest5.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = PendingSpecTest5.m; sourceTree = "<group>"; };
 		E91713F119DF07BB00921712 /* libSpecta.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = libSpecta.a; sourceTree = BUILT_PRODUCTS_DIR; };
 		E917140919DF07D700921712 /* libSpecta.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = libSpecta.a; sourceTree = BUILT_PRODUCTS_DIR; };
 		E9288BE619BE182900DE96FA /* XCTest.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = XCTest.framework; path = Platforms/MacOSX.platform/Developer/Library/Frameworks/XCTest.framework; sourceTree = DEVELOPER_DIR; };
@@ -473,6 +476,7 @@
 				E963ABFB1968E15400A592DF /* PendingSpecTest2.m */,
 				E963ABFC1968E15400A592DF /* PendingSpecTest3.m */,
 				E982173419C758B90056C9BF /* PendingSpecTest4.m */,
+				D0D022251AB8B983000DC090 /* PendingSpecTest5.m */,
 				E963ABFD1968E15400A592DF /* ReRunTest.m */,
 				E963ABFE1968E15400A592DF /* SequenceTest.m */,
 				E963ABFF1968E15400A592DF /* SharedExamplesTest1.m */,
@@ -856,6 +860,7 @@
 				E963AC241968E15400A592DF /* DSLTest3.m in Sources */,
 				E963AC0C1968E15400A592DF /* AsyncSpecTest3.m in Sources */,
 				E963AC201968E15400A592DF /* DSLTest1.m in Sources */,
+				D0D022261AB8B983000DC090 /* PendingSpecTest5.m in Sources */,
 				E963AC3A1968E15400A592DF /* ReRunTest.m in Sources */,
 				E963AC461968E15400A592DF /* SharedExamplesTest5.m in Sources */,
 				E982173519C758B90056C9BF /* PendingSpecTest4.m in Sources */,
@@ -916,6 +921,7 @@
 				E963AC251968E15400A592DF /* DSLTest3.m in Sources */,
 				E963AC0D1968E15400A592DF /* AsyncSpecTest3.m in Sources */,
 				E963AC211968E15400A592DF /* DSLTest1.m in Sources */,
+				D0D022271AB8B983000DC090 /* PendingSpecTest5.m in Sources */,
 				E963AC3B1968E15400A592DF /* ReRunTest.m in Sources */,
 				E963AC471968E15400A592DF /* SharedExamplesTest5.m in Sources */,
 				E982173619C758B90056C9BF /* PendingSpecTest4.m in Sources */,
@@ -1352,6 +1358,7 @@
 				E917140019DF07BB00921712 /* Release */,
 			);
 			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
 		};
 		E917141719DF07D700921712 /* Build configuration list for PBXNativeTarget "libSpecta-iOS" */ = {
 			isa = XCConfigurationList;
@@ -1360,6 +1367,7 @@
 				E917141919DF07D700921712 /* Release */,
 			);
 			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
 		};
 		E9536CD21968D30B003D1FBA /* Build configuration list for PBXProject "Specta" */ = {
 			isa = XCConfigurationList;

--- a/Specta/Specta/SPTExampleGroup.m
+++ b/Specta/Specta/SPTExampleGroup.m
@@ -273,7 +273,7 @@ typedef NS_ENUM(NSInteger, SPTExampleGroupOrder) {
 
 - (void)runAfterAllHooks:(NSString *)compiledName {
   for (SPTExampleGroup *group in [self exampleGroupStackInOrder:SPTExampleGroupOrderInnermostFirst]) {
-    if (group.ranExampleCount + group.pendingExampleCount == group.exampleCount) {
+    if (group.ranExampleCount == group.exampleCount) {
       for (id afterAllBlock in group.afterAllArray) {
         runExampleBlock(afterAllBlock, [NSString stringWithFormat:@"%@ - after all block", compiledName]);
       }
@@ -321,7 +321,9 @@ typedef NS_ENUM(NSInteger, SPTExampleGroupOrder) {
       // Otherwise, run the example and all before and after hooks.
       SPTSpecBlock compiledBlock = example.pending ? ^(SPTSpec *spec){
         @synchronized(self.root) {
+          [self resetRanExampleCountIfNeeded];
           [self runBeforeAllHooks:compiledName];
+          [self incrementRanExampleCount];
           [self runAfterAllHooks:compiledName];
         }
       } : ^(SPTSpec *spec) {

--- a/Specta/SpectaTests/PendingSpecTest5.m
+++ b/Specta/SpectaTests/PendingSpecTest5.m
@@ -1,0 +1,43 @@
+#import "TestHelper.h"
+
+static int
+beforeAllRan
+, afterAllRan
+;
+
+SpecBegin(_PendingSpecTest5)
+
+describe(@"group", ^{
+  beforeAll(^{
+    beforeAllRan ++;
+  });
+
+  pending(@"pending 1", ^{ });
+  pending(@"pending 2", ^{ });
+
+  it(@"example 1", ^{ });
+  it(@"example 2", ^{ });
+
+  pending(@"pending 3", ^{ });
+  pending(@"pending 4", ^{ });
+
+  afterAll(^{
+    afterAllRan ++;
+  });
+});
+
+SpecEnd
+
+@interface PendingSpecTest5 : XCTestCase; @end
+@implementation PendingSpecTest5
+
+- (void)testPendingSpec {
+  beforeAllRan = afterAllRan = 0;
+
+  RunSpec(_PendingSpecTest5Spec);
+
+  assertEqual(beforeAllRan, 1);
+  assertEqual(afterAllRan, 1);
+}
+
+@end


### PR DESCRIPTION
This patch resets (if needed) and increments the number of ran test cases also for pending test cases.

It fixes a problem that the `afterAll` or `beforeAll` blocks might ran multiple times.
This would happen when you declare pending blocks as your first or last blocks

In this case of `afterAll`, the comparison `group.ranExampleCount + group.pendingExampleCount == group.exampleCount` will always be true, leading to the multiple execution of the `afterAll` blocks.

The same is applied for `beforeAll`. If the pending blocks are declared before the other test cases, the comparison `group.ranExampleCount == 0` will be true and the `beforeAll` blocks will be called multiple times.

Fixes #124 