### PR TITLE
Whitelist classes for global before/after hooks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+Upcoming
+=======
+
+* BREAKING: Whitelist classes for inclusion in global beforeEach and afterEach hooks, instead of blacklisting for exclusion. See `SPTGlobalBeforeAfterEach` [wasnotrice]
+
 v0.4
 ======
 * Makes it easy to skip the beforeEach/afterEach functions for specific classes

--- a/Specta/Specta.xcodeproj/project.pbxproj
+++ b/Specta/Specta.xcodeproj/project.pbxproj
@@ -7,7 +7,7 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
-		078CBC441ACCFC94000BC9FF /* SPTIncludeGlobalBeforeAfterEach.h in Headers */ = {isa = PBXBuildFile; fileRef = 078CBC431ACCFC94000BC9FF /* SPTIncludeGlobalBeforeAfterEach.h */; };
+		078CBC441ACCFC94000BC9FF /* SPTGlobalBeforeAfterEach.h in Headers */ = {isa = PBXBuildFile; fileRef = 078CBC431ACCFC94000BC9FF /* SPTGlobalBeforeAfterEach.h */; };
 		B27A96FD931E25BE3F7E615E /* SPTExcludeGlobalBeforeAfterEach.h in Headers */ = {isa = PBXBuildFile; fileRef = B27A9A666AF7370DC4D7F211 /* SPTExcludeGlobalBeforeAfterEach.h */; };
 		D0D022261AB8B983000DC090 /* PendingSpecTest5.m in Sources */ = {isa = PBXBuildFile; fileRef = D0D022251AB8B983000DC090 /* PendingSpecTest5.m */; };
 		D0D022271AB8B983000DC090 /* PendingSpecTest5.m in Sources */ = {isa = PBXBuildFile; fileRef = D0D022251AB8B983000DC090 /* PendingSpecTest5.m */; };
@@ -264,7 +264,7 @@
 /* End PBXContainerItemProxy section */
 
 /* Begin PBXFileReference section */
-		078CBC431ACCFC94000BC9FF /* SPTIncludeGlobalBeforeAfterEach.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = SPTIncludeGlobalBeforeAfterEach.h; sourceTree = "<group>"; };
+		078CBC431ACCFC94000BC9FF /* SPTGlobalBeforeAfterEach.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = SPTGlobalBeforeAfterEach.h; sourceTree = "<group>"; };
 		B27A9A666AF7370DC4D7F211 /* SPTExcludeGlobalBeforeAfterEach.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = SPTExcludeGlobalBeforeAfterEach.h; sourceTree = "<group>"; };
 		D0D022251AB8B983000DC090 /* PendingSpecTest5.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = PendingSpecTest5.m; sourceTree = "<group>"; };
 		E91713F119DF07BB00921712 /* libSpecta.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = libSpecta.a; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -443,7 +443,7 @@
 				E963ABAE1968E13800A592DF /* XCTestCase+Specta.h */,
 				E963ABAF1968E13800A592DF /* XCTestCase+Specta.m */,
 				B27A9A666AF7370DC4D7F211 /* SPTExcludeGlobalBeforeAfterEach.h */,
-				078CBC431ACCFC94000BC9FF /* SPTIncludeGlobalBeforeAfterEach.h */,
+				078CBC431ACCFC94000BC9FF /* SPTGlobalBeforeAfterEach.h */,
 			);
 			path = Specta;
 			sourceTree = "<group>";
@@ -555,7 +555,7 @@
 				E963ABB41968E13800A592DF /* Specta.h in Headers */,
 				E963ABBA1968E13800A592DF /* SpectaTypes.h in Headers */,
 				B27A96FD931E25BE3F7E615E /* SPTExcludeGlobalBeforeAfterEach.h in Headers */,
-				078CBC441ACCFC94000BC9FF /* SPTIncludeGlobalBeforeAfterEach.h in Headers */,
+				078CBC441ACCFC94000BC9FF /* SPTGlobalBeforeAfterEach.h in Headers */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/Specta/Specta.xcodeproj/project.pbxproj
+++ b/Specta/Specta.xcodeproj/project.pbxproj
@@ -7,6 +7,7 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		078CBC441ACCFC94000BC9FF /* SPTIncludeGlobalBeforeAfterEach.h in Headers */ = {isa = PBXBuildFile; fileRef = 078CBC431ACCFC94000BC9FF /* SPTIncludeGlobalBeforeAfterEach.h */; };
 		B27A96FD931E25BE3F7E615E /* SPTExcludeGlobalBeforeAfterEach.h in Headers */ = {isa = PBXBuildFile; fileRef = B27A9A666AF7370DC4D7F211 /* SPTExcludeGlobalBeforeAfterEach.h */; };
 		D0D022261AB8B983000DC090 /* PendingSpecTest5.m in Sources */ = {isa = PBXBuildFile; fileRef = D0D022251AB8B983000DC090 /* PendingSpecTest5.m */; };
 		D0D022271AB8B983000DC090 /* PendingSpecTest5.m in Sources */ = {isa = PBXBuildFile; fileRef = D0D022251AB8B983000DC090 /* PendingSpecTest5.m */; };
@@ -263,6 +264,7 @@
 /* End PBXContainerItemProxy section */
 
 /* Begin PBXFileReference section */
+		078CBC431ACCFC94000BC9FF /* SPTIncludeGlobalBeforeAfterEach.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = SPTIncludeGlobalBeforeAfterEach.h; sourceTree = "<group>"; };
 		B27A9A666AF7370DC4D7F211 /* SPTExcludeGlobalBeforeAfterEach.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = SPTExcludeGlobalBeforeAfterEach.h; sourceTree = "<group>"; };
 		D0D022251AB8B983000DC090 /* PendingSpecTest5.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = PendingSpecTest5.m; sourceTree = "<group>"; };
 		E91713F119DF07BB00921712 /* libSpecta.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = libSpecta.a; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -441,6 +443,7 @@
 				E963ABAE1968E13800A592DF /* XCTestCase+Specta.h */,
 				E963ABAF1968E13800A592DF /* XCTestCase+Specta.m */,
 				B27A9A666AF7370DC4D7F211 /* SPTExcludeGlobalBeforeAfterEach.h */,
+				078CBC431ACCFC94000BC9FF /* SPTIncludeGlobalBeforeAfterEach.h */,
 			);
 			path = Specta;
 			sourceTree = "<group>";
@@ -552,6 +555,7 @@
 				E963ABB41968E13800A592DF /* Specta.h in Headers */,
 				E963ABBA1968E13800A592DF /* SpectaTypes.h in Headers */,
 				B27A96FD931E25BE3F7E615E /* SPTExcludeGlobalBeforeAfterEach.h in Headers */,
+				078CBC441ACCFC94000BC9FF /* SPTIncludeGlobalBeforeAfterEach.h in Headers */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/Specta/Specta/SPTExampleGroup.m
+++ b/Specta/Specta/SPTExampleGroup.m
@@ -19,7 +19,7 @@ static NSArray *ClassesWithClassMethod(SEL classMethodSelector) {
     for(int classIndex = 0; classIndex < numberOfClasses; classIndex++) {
       Class aClass = classes[classIndex];
 
-      if (class_conformsToProtocol(aClass, @protocol(SPTGlobalBeforeAfterEach)) == YES) {
+      if (class_conformsToProtocol(aClass, @protocol(SPTGlobalBeforeAfterEach))) {
         Method globalMethod = class_getClassMethod(aClass, classMethodSelector);
         if (globalMethod) {
           [classesWithClassMethod addObject:aClass];

--- a/Specta/Specta/SPTExampleGroup.m
+++ b/Specta/Specta/SPTExampleGroup.m
@@ -4,7 +4,7 @@
 #import "SPTSpec.h"
 #import "SpectaUtility.h"
 #import "XCTest+Private.h"
-#import "SPTIncludeGlobalBeforeAfterEach.h"
+#import "SPTGlobalBeforeAfterEach.h"
 #import <libkern/OSAtomic.h>
 #import <objc/runtime.h>
 
@@ -19,7 +19,7 @@ static NSArray *ClassesWithClassMethod(SEL classMethodSelector) {
     for(int classIndex = 0; classIndex < numberOfClasses; classIndex++) {
       Class aClass = classes[classIndex];
 
-      if (class_conformsToProtocol(aClass, @protocol(SPTIncludeGlobalBeforeAfterEach)) == YES) {
+      if (class_conformsToProtocol(aClass, @protocol(SPTGlobalBeforeAfterEach)) == YES) {
         Method globalMethod = class_getClassMethod(aClass, classMethodSelector);
         if (globalMethod) {
           [classesWithClassMethod addObject:aClass];
@@ -46,7 +46,7 @@ typedef NS_ENUM(NSInteger, SPTExampleGroupOrder) {
   SPTExampleGroupOrderInnermostFirst
 };
 
-@interface SPTExampleGroup () <SPTIncludeGlobalBeforeAfterEach>
+@interface SPTExampleGroup () <SPTGlobalBeforeAfterEach>
 
 - (void)incrementExampleCount;
 - (void)incrementPendingExampleCount;

--- a/Specta/Specta/SPTExcludeGlobalBeforeAfterEach.h
+++ b/Specta/Specta/SPTExcludeGlobalBeforeAfterEach.h
@@ -5,6 +5,6 @@
 
 // This protocol was used for blacklisting classes for global beforeEach and afterEach blocks.
 // Now, instead, classes are whitelisted by implementing the SPTGlobalBeforeAfterEach protocol.
-__deprecated
+__deprecated_msg("Please whitelist classes instead with the SPTGlobalBeforeAfterEach protocol")
 @protocol SPTExcludeGlobalBeforeAfterEach <NSObject>
 @end

--- a/Specta/Specta/SPTExcludeGlobalBeforeAfterEach.h
+++ b/Specta/Specta/SPTExcludeGlobalBeforeAfterEach.h
@@ -3,8 +3,8 @@
  */
 #import <Foundation/Foundation.h>
 
-// This protocol is used for blacklisting classes for global beforeEach and afterEach blocks.
-// If you do not want a class to participate in those just add this protocol to a category and it will be
-// excluded.
+// This protocol was used for blacklisting classes for global beforeEach and afterEach blocks.
+// Now, instead, classes are whitelisted by implementing the SPTIncludeGlobalBeforeAfterEach protocol.
+__deprecated
 @protocol SPTExcludeGlobalBeforeAfterEach <NSObject>
 @end

--- a/Specta/Specta/SPTExcludeGlobalBeforeAfterEach.h
+++ b/Specta/Specta/SPTExcludeGlobalBeforeAfterEach.h
@@ -4,7 +4,7 @@
 #import <Foundation/Foundation.h>
 
 // This protocol was used for blacklisting classes for global beforeEach and afterEach blocks.
-// Now, instead, classes are whitelisted by implementing the SPTIncludeGlobalBeforeAfterEach protocol.
+// Now, instead, classes are whitelisted by implementing the SPTGlobalBeforeAfterEach protocol.
 __deprecated
 @protocol SPTExcludeGlobalBeforeAfterEach <NSObject>
 @end

--- a/Specta/Specta/SPTGlobalBeforeAfterEach.h
+++ b/Specta/Specta/SPTGlobalBeforeAfterEach.h
@@ -6,7 +6,7 @@
 // This protocol is used for whitelisting classes for global beforeEach and afterEach blocks.
 // If you want a class to participate in those just add this protocol to a category and it will be
 // included.
-@protocol SPTIncludeGlobalBeforeAfterEach <NSObject>
+@protocol SPTGlobalBeforeAfterEach <NSObject>
 
 @optional
 + (void)beforeEach;

--- a/Specta/Specta/SPTIncludeGlobalBeforeAfterEach.h
+++ b/Specta/Specta/SPTIncludeGlobalBeforeAfterEach.h
@@ -1,0 +1,15 @@
+/*
+ * Copyright (c) 2015 Specta Team. All rights reserved.
+ */
+#import <Foundation/Foundation.h>
+
+// This protocol is used for whitelisting classes for global beforeEach and afterEach blocks.
+// If you want a class to participate in those just add this protocol to a category and it will be
+// included.
+@protocol SPTIncludeGlobalBeforeAfterEach <NSObject>
+
+@optional
++ (void)beforeEach;
++ (void)afterEach;
+
+@end

--- a/Specta/SpectaTests/SequenceTest.m
+++ b/Specta/SpectaTests/SequenceTest.m
@@ -1,8 +1,9 @@
 #import "TestHelper.h"
+#import "SPTIncludeGlobalBeforeAfterEach.h"
 
 static NSMutableArray *sequence = nil;
 
-@interface SequenceTestHelper : NSObject
+@interface SequenceTestHelper : NSObject <SPTIncludeGlobalBeforeAfterEach>
 @end
 
 @implementation SequenceTestHelper

--- a/Specta/SpectaTests/SequenceTest.m
+++ b/Specta/SpectaTests/SequenceTest.m
@@ -1,9 +1,9 @@
 #import "TestHelper.h"
-#import "SPTIncludeGlobalBeforeAfterEach.h"
+#import "SPTGlobalBeforeAfterEach.h"
 
 static NSMutableArray *sequence = nil;
 
-@interface SequenceTestHelper : NSObject <SPTIncludeGlobalBeforeAfterEach>
+@interface SequenceTestHelper : NSObject <SPTGlobalBeforeAfterEach>
 @end
 
 @implementation SequenceTestHelper


### PR DESCRIPTION
This change set addresses #148

When running global before and after hooks, we were picking up any class that implemented `+beforeEach` and/or `+afterEach`. You could opt-out by conforming to the `SPTExcludeGlobalBeforeAfterEach` protocol. This could cause difficult to debug failures if unwanted hooks were included, especially if they involved classes that the developer did not control.

This commit reverses the approach, creating a `SPTIncludeGlobalBeforeAfterEach` protocol, which `SPTExampleGroup` implements. With this change, we only select classes that implement `SPTIncludeGlobalBeforeAfterEach` for running global `+beforeEach` and/or `+afterEach`. You can opt-in by implementing the protocol.

This change seems to fix my spec failures, but I am not actually using global before/after hooks in my project, so this definitely could use some review/testing by folks who are. 