### PR TITLE
Set Specta-iOS deployment target to 7.0

### DIFF
--- a/Specta/Specta.xcodeproj/project.pbxproj
+++ b/Specta/Specta.xcodeproj/project.pbxproj
@@ -1275,6 +1275,7 @@
 				);
 				INFOPLIST_FILE = Specta/Info.plist;
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
+				IPHONEOS_DEPLOYMENT_TARGET = 7.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
 				METAL_ENABLE_DEBUG_INFO = YES;
 				OTHER_LDFLAGS = "-ObjC";
@@ -1303,6 +1304,7 @@
 				);
 				INFOPLIST_FILE = Specta/Info.plist;
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
+				IPHONEOS_DEPLOYMENT_TARGET = 7.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
 				METAL_ENABLE_DEBUG_INFO = NO;
 				OTHER_LDFLAGS = "-ObjC";


### PR DESCRIPTION
When attempting to import Specta as a dependency using Carthage, building the `Specta-iOS` scheme fails with the following error:

```
$ cat Cartfile
github "specta/specta"

$ carthage bootstrap
*** No Cartfile.resolved found, updating dependencies
*** Fetching specta
*** Checking out specta at "v1.0.0"
*** xcodebuild output can be found in /var/folders/fv/z_s5t3cn095c3ff9m1vj6dt83942tn/T/carthage-xcodebuild.qKnQrR.log
*** Building scheme "Specta" in Specta.xcworkspace
*** Building scheme "Specta-iOS" in Specta.xcworkspace
A shell task failed with exit code 70:
xcodebuild: error: Failed to build workspace Specta with scheme Specta-iOS.
	Reason: The run destination iPad 2 is not valid for Running the scheme 'Specta-iOS'.
```

Carthage aside, you can see that the underlying issue is actually in `xcodebuild`. For example:

```
$ xcodebuild -workspace Specta.xcworkspace -scheme Specta-iOS
xcodebuild: error: Failed to build workspace Specta with scheme Specta-iOS.
	Reason: The run destination iPad 2 is not valid for Running the scheme 'Specta-iOS'.
```

Specifying `iphoneos` with the `-sdk` flag appears to fix the issue and allows the framework to be built properly.

Understandably, the Cathage folks [aren't willing to add the ability to pass specific flags](https://github.com/Carthage/Carthage/issues/259#issuecomment-68292672) to work around bugs in `xcodebuild`.

As [@eunikolsky pointed out on #157](https://github.com/specta/specta/pull/157#issuecomment-106927835), this may have been a problem because the `Specta-iOS` target did not have a deployment target set. By setting it to 7.0, the problem appears to be resolved.