### PR TITLE
XCTestObservationCenter private methods support for new SDK

### DIFF
--- a/Specta/Specta/XCTest+Private.h
+++ b/Specta/Specta/XCTest+Private.h
@@ -1,11 +1,23 @@
 #import <XCTest/XCTest.h>
 
+#if __IPHONE_OS_VERSION_MAX_ALLOWED >= 90000 || __MAC_OS_X_VERSION_MAX_ALLOWED >= 101100
+
+@interface XCTestObservationCenter (SPTTestSuspention)
+
+- (void)_suspendObservationForBlock:(void (^)(void))block;
+
+@end
+
+#else
+
 @interface XCTestObservationCenter : NSObject
 
 + (id)sharedObservationCenter;
 - (void)_suspendObservationForBlock:(void (^)(void))block;
 
 @end
+
+#endif
 
 @protocol XCTestObservation <NSObject>
 @end

--- a/Specta/SpectaTests/TestHelper.h
+++ b/Specta/SpectaTests/TestHelper.h
@@ -1,12 +1,24 @@
 #import <XCTest/XCTest.h>
 #import <Specta/Specta.h>
 
+#if __IPHONE_OS_VERSION_MAX_ALLOWED >= 90000 || __MAC_OS_X_VERSION_MAX_ALLOWED >= 101100
+
+@interface XCTestObservationCenter (SPTTestSuspention)
+
+- (void)_suspendObservationForBlock:(void (^)(void))block;
+
+@end
+
+#else
+
 @interface XCTestObservationCenter
 
 + (id)sharedObservationCenter;
 - (void)_suspendObservationForBlock:(void (^)(void))block;
 
 @end
+
+#endif
 
 #define RunSpec(TestClass) RunSpecClass([TestClass class])
 

--- a/Specta/SpectaTests/TestHelper.m
+++ b/Specta/SpectaTests/TestHelper.m
@@ -3,7 +3,11 @@
 XCTestSuiteRun *RunSpecClass(Class testClass) {
   __block XCTestSuiteRun *result;
 
+#if __IPHONE_OS_VERSION_MAX_ALLOWED >= 90000 || __MAC_OS_X_VERSION_MAX_ALLOWED >= 101100
+  XCTestObservationCenter *observationCenter = [XCTestObservationCenter sharedTestObservationCenter];
+#else
   XCTestObservationCenter *observationCenter = [XCTestObservationCenter sharedObservationCenter];
+#endif
   [observationCenter _suspendObservationForBlock:^{
     result = (id)[(XCTestSuite *)[XCTestSuite testSuiteForTestCaseClass:testClass] run];
   }];


### PR DESCRIPTION
PR for Issue #164 
Since the `XCTestObservationCenter` class is now public, when building for the new SDKs, only specific private method is exposed as a category. 

Tested Specta with `rake test` with both 10.10 and 10.11 SDKs and as cocoa pod with iOS 8 and 9 SDKs.
