### PR TITLE
Add async test using XCTestExpectation

### DIFF
--- a/Specta/SpectaTests/AsyncSpecTest.m
+++ b/Specta/SpectaTests/AsyncSpecTest.m
@@ -35,6 +35,16 @@ describe(@"group", ^{
     });
   });
 
+  it(@"example 1", ^{
+    XCTestExpectation *expectation = [self expectationWithDescription:@"Async"];
+    dispatch_async(dispatch_get_main_queue(), ^{
+      assertEqualObjects(foo, @"foo");
+      [expectation fulfill];
+    });
+    [self waitForExpectationsWithTimeout:10 handler:nil];
+  });
+
+
   it(@"assert on background queue", ^{
     waitUntil(^(DoneCallback done) {
       dispatch_async(dispatch_get_global_queue(DISPATCH_QUEUE_PRIORITY_DEFAULT, 0), ^{
@@ -55,7 +65,7 @@ SpecEnd
   bar = @"not bar";
   XCTestRun *result = RunSpec(_AsyncSpecTestSpec);
   assertEqual([result unexpectedExceptionCount], 0);
-  assertEqual([result failureCount], 3);
+  assertEqual([result failureCount], 4);
   assertFalse([result hasSucceeded]);
   foo = @"foo";
   bar = @"bar";


### PR DESCRIPTION
We're encountering an issue using `XCTestExpectation` inside of a specta test in Xcode 7 beta 2. Works for us in Xcode 6.3.2.

When we run a test that uses `expectationWithDescription:` and `waitForExpectationsWithTimeout:handler:` in the Xcode beta, we see a crash coming out of XCTest:

` 'API violation - called -[XCTestExpectation fulfill] for Async after the test case in which the expectation was created is no longer running. Created in test -[_AsyncSpecTestSpec (null)], current test is -[_AsyncSpecTestSpec test_group__example_1_2]'`

Anyone know why the test name is inconsistent across the two calls?

Full stacktrace:
```
Test Suite 'All tests' started at 2015-07-01 13:37:43.590
Test Suite 'Specta.framework' started at 2015-07-01 13:37:43.590
Test Suite 'Specta.framework' passed at 2015-07-01 13:37:43.591.
	 Executed 0 tests, with 0 failures (0 unexpected) in 0.000 (0.000) seconds
Test Suite 'Specta-iOSTests.xctest' started at 2015-07-01 13:37:43.591
Test Suite 'AsyncSpecTest' started at 2015-07-01 13:37:43.591
Test Case '-[AsyncSpecTest testAsyncSpec]' started.
2015-07-01 13:37:43.920 xctest[62256:847232] *** Assertion failure in -[XCTestExpectation fulfill], /Library/Caches/com.apple.xbs/Sources/XCTest_Sim/XCTest-8102.21/XCTestFramework/Classes/XCTestCase+AsynchronousTesting.m:399
2015-07-01 13:37:43.921 xctest[62256:847232] *** Terminating app due to uncaught exception 'NSInternalInconsistencyException', reason: 'API violation - called -[XCTestExpectation fulfill] for Async after the test case in which the expectation was created is no longer running. Created in test -[_AsyncSpecTestSpec (null)], current test is -[_AsyncSpecTestSpec test_group__example_1_2]'
*** First throw call stack:
(
	0   CoreFoundation                      0x000000010c507ca5 __exceptionPreprocess + 165
	1   libobjc.A.dylib                     0x000000010bf80dcd objc_exception_throw + 48
	2   CoreFoundation                      0x000000010c507b0a +[NSException raise:format:arguments:] + 106
	3   Foundation                          0x000000010bbd3ff1 -[NSAssertionHandler handleFailureInMethod:object:file:lineNumber:description:] + 198
	4   XCTest                              0x000000010ba95291 XCTest + 299665
	5   Specta-iOSTests                     0x0000000116157b0c __26-[_AsyncSpecTestSpec spec]_block_invoke_273 + 1052
	6   libdispatch.dylib                   0x000000010e6d4b61 _dispatch_call_block_and_release + 12
	7   libdispatch.dylib                   0x000000010e6efaa1 _dispatch_client_callout + 8
	8   libdispatch.dylib                   0x000000010e6da805 _dispatch_main_queue_callback_4CF + 706
	9   CoreFoundation                      0x000000010c467459 __CFRUNLOOP_IS_SERVICING_THE_MAIN_DISPATCH_QUEUE__ + 9
	10  CoreFoundation                      0x000000010c427ef9 __CFRunLoopRun + 2073
	11  CoreFoundation                      0x000000010c427458 CFRunLoopRunSpecific + 488
	12  Foundation                          0x000000010bb748cd -[NSRunLoop(NSRunLoop) runMode:beforeDate:] + 267
	13  XCTest                              0x000000010ba94a41 XCTest + 297537
	14  Specta-iOSTests                     0x00000001161576b3 __26-[_AsyncSpecTestSpec spec]_block_invoke68 + 355
	15  Specta                              0x0000000117184818 runExampleBlock + 264
	16  Specta                              0x000000011718754a __44-[SPTExampleGroup compileExamplesWithStack:]_block_invoke140 + 394
	17  Specta                              0x000000011718fe65 -[SPTSpec spt_runExample:] + 421
	18  Specta                              0x000000011718f6df __35+[SPTSpec spt_convertToTestMethod:]_block_invoke + 127
	19  CoreFoundation                      0x000000010c3f4cfc __invoking___ + 140
	20  CoreFoundation                      0x000000010c3f4b4e -[NSInvocation invoke] + 286
	21  XCTest                              0x000000010ba63efe XCTest + 98046
	22  XCTest                              0x000000010ba641f6 XCTest + 98806
	23  Specta                              0x0000000117190e86 -[SPTSpec performTest:] + 166
	24  XCTest                              0x000000010ba6209f XCTest + 90271
	25  XCTest                              0x000000010ba81a48 XCTest + 219720
	26  Specta-iOSTests                     0x0000000116117cec __RunSpecClass_block_invoke + 124
	27  XCTest                              0x000000010ba6dcb4 XCTest + 138420
	28  Specta-iOSTests                     0x0000000116117a59 RunSpecClass + 313
	29  Specta-iOSTests                     0x000000011615943e -[AsyncSpecTest testAsyncSpec] + 158
	30  CoreFoundation                      0x000000010c3f4cfc __invoking___ + 140
	31  CoreFoundation                      0x000000010c3f4b4e -[NSInvocation invoke] + 286
	32  XCTest                              0x000000010ba63efe XCTest + 98046
	33  XCTest                              0x000000010ba641f6 XCTest + 98806
	34  XCTest                              0x000000010ba6209f XCTest + 90271
	35  XCTest                              0x000000010ba6209f XCTest + 90271
	36  XCTest                              0x000000010ba6209f XCTest + 90271
	37  XCTest                              0x000000010ba5065a XCTest + 18010
	38  XCTest                              0x000000010ba6d9d0 XCTest + 137680
	39  XCTest                              0x000000010ba505a6 XCTest + 17830
	40  XCTest                              0x000000010ba50fa1 XCTest + 20385
	41  XCTest                              0x000000010ba8cfcc XCTest + 266188
	42  xctest                              0x000000010b9de571 xctest + 5489
	43  libdyld.dylib                       0x000000010e71f92d libdyld.dylib + 10541
	44  ???                                 0x0000000000000005 0x0 + 5
)
libc++abi.dylib: terminating with uncaught exception of type NSException
(lldb) 
```

PR contains a new test for specta that reproduces the issue.