### PR TITLE
remove framework_search_paths from podspec

### DIFF
--- a/Specta.podspec
+++ b/Specta.podspec
@@ -14,6 +14,4 @@ Pod::Spec.new do |s|
   s.requires_arc    = true
   s.ios.deployment_target = '6.0'
   s.osx.deployment_target = '10.8'
-  s.osx.xcconfig    = { 'FRAMEWORK_SEARCH_PATHS' => '$(inherited) $(DEVELOPER_FRAMEWORKS_DIR) "$(PLATFORM_DIR)/Developer/Library/Frameworks" "$(DEVELOPER_DIR)/Platforms/MacOSX.platform/Developer/Library/Frameworks"' }
-  s.ios.xcconfig    = { 'FRAMEWORK_SEARCH_PATHS' => '$(inherited) $(DEVELOPER_FRAMEWORKS_DIR) "$(PLATFORM_DIR)/Developer/Library/Frameworks" "$(DEVELOPER_DIR)/Platforms/iPhoneSimulator.platform/Developer/Library/Frameworks"' }
 end


### PR DESCRIPTION
In Xcode 7, the `FRAMEWORK_SEARCH_PATHS` added by the Specta podspec cause build warnings. After experimenting removal of the values it adds to the generated xcconfig file, my targets build and tests run without warnings. I don't believe the pod requires any of these paths added by the podspec.

<img width="454" alt="screen shot 2015-09-15 at 5 47 45 pm" src="https://cloud.githubusercontent.com/assets/1057077/9915613/0e9ee2e2-5c86-11e5-95b2-8cd4eba0cc7f.png">
