### PR TITLE
rm XCTestObservation redefinition

### DIFF
--- a/Specta/Specta/XCTest+Private.h
+++ b/Specta/Specta/XCTest+Private.h
@@ -19,9 +19,6 @@
 
 #endif
 
-@protocol XCTestObservation <NSObject>
-@end
-
 @interface _XCTestDriverTestObserver : NSObject <XCTestObservation>
 
 - (void)stopObserving;


### PR DESCRIPTION
I removed `XCTestObservation` redefinition in `XCTest+Private.h`, because it was generating a warning. I also didn't notice any specific reason to keep this redefinition, so I assumed it's not needed.