### PR TITLE
Make Specta compatible with xctool and Xcode 7.

### DIFF
--- a/Specta/Specta/SPTSpec.m
+++ b/Specta/Specta/SPTSpec.m
@@ -33,6 +33,7 @@
     [self spt_unsetCurrentTestSuite];
   }
   [testSuite compile];
+  [[self class] testInvocations];
   [super initialize];
 }
 


### PR DESCRIPTION
Fixed https://github.com/facebook/xctool/issues/572.

Tested on https://github.com/arcam/CocoaUPnP/tree/xcode7.