### PR TITLE
Xcode 7 + Carthage + Dynamic Modules

### DIFF
--- a/Specta/Specta.xcodeproj/project.pbxproj
+++ b/Specta/Specta.xcodeproj/project.pbxproj
@@ -1277,7 +1277,7 @@
 				);
 				INFOPLIST_FILE = Specta/Info.plist;
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
-				IPHONEOS_DEPLOYMENT_TARGET = 7.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
 				METAL_ENABLE_DEBUG_INFO = YES;
 				OTHER_LDFLAGS = "-ObjC";
@@ -1306,7 +1306,7 @@
 				);
 				INFOPLIST_FILE = Specta/Info.plist;
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
-				IPHONEOS_DEPLOYMENT_TARGET = 7.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
 				METAL_ENABLE_DEBUG_INFO = NO;
 				OTHER_LDFLAGS = "-ObjC";

--- a/Specta/Specta/XCTest+Private.h
+++ b/Specta/Specta/XCTest+Private.h
@@ -17,10 +17,11 @@
 
 @end
 
-#endif
-
 @protocol XCTestObservation <NSObject>
 @end
+
+
+#endif
 
 @interface _XCTestDriverTestObserver : NSObject <XCTestObservation>
 


### PR DESCRIPTION
- Upgrades min version to iOS8 in framework (not supported before)
- Removes XCTestObservation protocol for iOS9+