### PR TITLE
Disable bitcode for Specta when installed through Cocoapods

### DIFF
--- a/Specta.podspec
+++ b/Specta.podspec
@@ -14,4 +14,5 @@ Pod::Spec.new do |s|
   s.requires_arc    = true
   s.ios.deployment_target = '6.0'
   s.osx.deployment_target = '10.8'
+  s.pod_target_xcconfig = { 'ENABLE_BITCODE' => 'NO' }
 end


### PR DESCRIPTION
Fixes #178 for CocoaPods users.