### PR TITLE
Resolve CI issues in Xcode 7

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -13,8 +13,8 @@ def execute(command, stdout=nil)
   system(command) or raise "** BUILD FAILED **"
 end
 
-def test(scheme)
-  execute "xcrun xcodebuild -workspace #{WORKSPACE} -scheme #{scheme} -configuration #{CONFIGURATION} test SYMROOT=build | xcpretty -c && exit ${PIPESTATUS[0]}"
+def test(scheme, sdk)
+  execute "xcrun xcodebuild -sdk #{sdk} -workspace #{WORKSPACE} -scheme #{scheme} -configuration #{CONFIGURATION} test SYMROOT=build | xcpretty -c && exit ${PIPESTATUS[0]}"
 end
 
 def build(scheme, sdk, product)
@@ -129,11 +129,11 @@ end
 
 namespace 'specs' do
   task :ios => :clean do |t|
-    test("Specta-iOS")
+    test("Specta-iOS", "iphonesimulator")
   end
 
   task :osx => :clean do |t|
-    test("Specta")
+    test("Specta", "macosx")
   end
 end
 


### PR DESCRIPTION
I do not fully understand what happens here:
The behavior of executing test suites seems to have changed in Xcode 7. If not explicitly setting the build sdk to `iphonesimulator`, Xcode 7 will try to code sign the unit test bundle and the included frameworks even when running on a Simulator, whereas previous versions of xcode did not. 

Adding the `-sdk` flag to the xcodebuild call and telling it to use the iphonesimulator sdk fixes the current CI failures.