### PR TITLE
`rake` responds to CODE_SIGN_IDENTITY

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -7,6 +7,10 @@ CONFIGURATION = 'Release'
 NO_COLOR= "\033[0m"
 GREEN_COLOR = "\033[32;01m"
 
+def code_sign_identity
+  ENV['CODE_SIGN_IDENTITY'] || 'iPhone Developer'
+end
+
 def execute(command, stdout=nil)
   puts "Running #{command}..."
   command += " > #{stdout}" if stdout
@@ -33,10 +37,6 @@ end
 
 def lipo(bin1, bin2, output)
   execute "xcrun lipo -create '#{bin1}' '#{bin2}' -output '#{output}'"
-end
-
-def code_signing_identity
-  ENV['SPT_CODE_SIGNING_IDENTITY'] || 'iPhone Developer'
 end
 
 def clean(scheme)
@@ -90,7 +90,7 @@ task :build => :clean do |t|
   lipo(ios_static_lib, ios_sim_static_lib, ios_univ_static_lib)
 
   puts_green "\n=== CODESIGN iOS FRAMEWORK ==="
-  execute "xcrun codesign --force --sign \"#{code_signing_identity}\" --resource-rules='#{ios_univ_framework}'/ResourceRules.plist '#{ios_univ_framework}'"
+  execute "xcrun codesign --force --sign \"#{code_sign_identity}\" --resource-rules='#{ios_univ_framework}'/ResourceRules.plist '#{ios_univ_framework}'"
 
   puts_green "\n=== COPY PRODUCTS ==="
   execute "yes | rm -rf Products"

--- a/Rakefile
+++ b/Rakefile
@@ -8,7 +8,10 @@ NO_COLOR= "\033[0m"
 GREEN_COLOR = "\033[32;01m"
 
 def code_sign_identity
-  ENV['CODE_SIGN_IDENTITY'] || 'iPhone Developer'
+  ENV['CODE_SIGN_IDENTITY'] ||
+    # Legacy support.
+    ENV["SPT_CODE_SIGNING_IDENTITY"] ||
+   'iPhone Developer'
 end
 
 def execute(command, stdout=nil)


### PR DESCRIPTION
### Motivation

In this [commit]( https://github.com/specta/specta/commit/806c901dddc84130b60fe825afb2a4cbdb9ae012)  I added support for specifying the code signing identity to support users who receive:

```
iPhone Developer: ambiguous (matches "iPhone Developer: XXX" and "iPhone Developer: YYY")
```

in the iOS code signing step.

With more experience under my belt, I think it is no longer necessary to use `SPT_CODE_SIGNING_IDENTITY` environment variable - the script should respond to `CODE_SIGN_IDENTITY` as `xcodebuild` does.

`SPT_CODE_SIGNING_IDENTITY` has been retained for backward compatibility.