### PR TITLE
Typo: occured -> occurred

### DIFF
--- a/Specta/Specta/SPTSpec.m
+++ b/Specta/Specta/SPTSpec.m
@@ -19,7 +19,7 @@
     [spec spec];
   }
   @catch (NSException *exception) {
-    fprintf(stderr, "%s: An exception has occured outside of tests, aborting.\n\n%s (%s) \n", [specName UTF8String], [[exception name] UTF8String], [[exception reason] UTF8String]);
+    fprintf(stderr, "%s: An exception has occurred outside of tests, aborting.\n\n%s (%s) \n", [specName UTF8String], [[exception name] UTF8String], [[exception reason] UTF8String]);
     if ([exception respondsToSelector:@selector(callStackSymbols)]) {
       NSArray *callStackSymbols = [exception callStackSymbols];
       if (callStackSymbols) {


### PR DESCRIPTION
Tiny typo, was fixing my own references, noticed this in the Pod.