### PR TITLE
Don’t dequeue failures on another thread for non Specta tests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 Master
 
 * Log out when skipping a not-focused spec [orta]
+* Fixed spt_dequeueFailures causing deadlock when running vanilla `XCTestCase` with `XCTestExpectation` [MatejBalantic]
 
 v1.0.5
 ======

--- a/Specta/Specta/XCTestCase+Specta.m
+++ b/Specta/Specta/XCTestCase+Specta.m
@@ -42,7 +42,10 @@
     [self spt_dequeueFailures];
   };
 
-  if ([NSThread isMainThread]) {
+  BOOL isMainThread = [NSThread isMainThread];
+  BOOL isSpectaTest = [self isKindOfClass:[SPTSpec class]];
+
+  if (!isSpectaTest || isMainThread) {
     dequeueFailures();
   } else {
     dispatch_sync(dispatch_get_main_queue(), dequeueFailures);


### PR DESCRIPTION
Steps to reproduce:

1. Create new project
2. Add Specta
3. Write a standard `XCTestCase` with an `XCTestExpectation`, set a reasonable timeout and make sure it does not get fulfilled
4. 💥 Deadlock happens. Tests will never complete.

Please find a bug reproduced in this example project:
https://github.com/MatejBalantic/Specta-Deadlock

Just run the unit tests.


In this PR we make sure that Specta swizzling/dispatching only happens for subclasses of `SPTSpec`. 

I've run the tests in XCode 8 using the changes from this PR https://github.com/specta/specta/pull/213  and they pass. I am unable to write a test for this, as writing the test would mean I need to fail a test first. I was able to prove the change helps though.

If anyone has idea about how to add a test that expects and expectation to fail I am happy to add it :) 

