### PR TITLE
SpectaDSL: dictionary objects' life time bug fix.

### DIFF
--- a/Specta/Specta/SpectaDSL.m
+++ b/Specta/Specta/SpectaDSL.m
@@ -52,11 +52,14 @@ void spt_itShouldBehaveLike_(NSString *fileName, NSUInteger lineNumber, NSString
 
         beforeEach(^{
           NSDictionary *blockData = dataBlock();
-          [dataDict removeAllObjects];
           [dataDict addEntriesFromDictionary:blockData];
         });
 
         block(dataDict);
+
+        afterEach(^{
+          [dataDict removeAllObjects];
+        });
 
         afterAll(^{
           dataDict = nil;


### PR DESCRIPTION
Dictionaries objects aren't release properly, when the test ends. This behavior causes problems when working with OpenGL based project.