### PR TITLE
Fix Xcode 9 warning about block declaration prototype

### DIFF
--- a/Specta/Specta/SPTExampleGroup.m
+++ b/Specta/Specta/SPTExampleGroup.m
@@ -33,7 +33,7 @@ static NSArray *ClassesWithClassMethod(SEL classMethodSelector) {
   return classesWithClassMethod;
 }
 
-static void runExampleBlock(void (^block)(), NSString *name) {
+static void runExampleBlock(void (^block)(void), NSString *name) {
   if (!SPTIsBlock(block)) {
     return;
   }

--- a/Specta/Specta/SpectaDSL.m
+++ b/Specta/Specta/SpectaDSL.m
@@ -10,7 +10,7 @@
 
 static NSTimeInterval asyncSpecTimeout = 10.0;
 
-static void spt_defineItBlock(NSString *name, NSString *fileName, NSUInteger lineNumber, BOOL focused, void (^block)()) {
+static void spt_defineItBlock(NSString *name, NSString *fileName, NSUInteger lineNumber, BOOL focused, void (^block)(void)) {
   SPTReturnUnlessBlockOrNil(block);
   SPTCallSite *site = nil;
   if (lineNumber && fileName) {
@@ -19,7 +19,7 @@ static void spt_defineItBlock(NSString *name, NSString *fileName, NSUInteger lin
   [SPTCurrentGroup addExampleWithName:name callSite:site focused:focused block:block];
 }
 
-static void spt_defineDescribeBlock(NSString *name, BOOL focused, void (^block)()) {
+static void spt_defineDescribeBlock(NSString *name, BOOL focused, void (^block)(void)) {
   if (block) {
     [SPTGroupStack addObject:[SPTCurrentGroup addExampleGroupWithName:name focused:focused]];
     block();
@@ -29,11 +29,11 @@ static void spt_defineDescribeBlock(NSString *name, BOOL focused, void (^block)(
   }
 }
 
-void spt_it_(NSString *name, NSString *fileName, NSUInteger lineNumber, void (^block)()) {
+void spt_it_(NSString *name, NSString *fileName, NSUInteger lineNumber, void (^block)(void)) {
   spt_defineItBlock(name, fileName, lineNumber, NO, block);
 }
 
-void spt_fit_(NSString *name, NSString *fileName, NSUInteger lineNumber, void (^block)()) {
+void spt_fit_(NSString *name, NSString *fileName, NSUInteger lineNumber, void (^block)(void)) {
   spt_defineItBlock(name, fileName, lineNumber, YES, block);
 }
 
@@ -84,75 +84,75 @@ void spt_itShouldBehaveLike_(NSString *fileName, NSUInteger lineNumber, NSString
   }
 }
 
-void spt_itShouldBehaveLike_block(NSString *fileName, NSUInteger lineNumber, NSString *name, NSDictionary *(^block)()) {
+void spt_itShouldBehaveLike_block(NSString *fileName, NSUInteger lineNumber, NSString *name, NSDictionary *(^block)(void)) {
   spt_itShouldBehaveLike_(fileName, lineNumber, name, (id)block);
 }
 
-void describe(NSString *name, void (^block)()) {
+void describe(NSString *name, void (^block)(void)) {
   spt_defineDescribeBlock(name, NO, block);
 }
 
-void fdescribe(NSString *name, void (^block)()) {
+void fdescribe(NSString *name, void (^block)(void)) {
   spt_defineDescribeBlock(name, YES, block);
 }
 
-void context(NSString *name, void (^block)()) {
+void context(NSString *name, void (^block)(void)) {
   describe(name, block);
 }
 
-void fcontext(NSString *name, void (^block)()) {
+void fcontext(NSString *name, void (^block)(void)) {
   fdescribe(name, block);
 }
 
-void it(NSString *name, void (^block)()) {
+void it(NSString *name, void (^block)(void)) {
   spt_defineItBlock(name, nil, 0, NO, block);
 }
 
-void fit(NSString *name, void (^block)()) {
+void fit(NSString *name, void (^block)(void)) {
   spt_defineItBlock(name, nil, 0, YES, block);
 }
 
-void example(NSString *name, void (^block)()) {
+void example(NSString *name, void (^block)(void)) {
   it(name, block);
 }
 
-void fexample(NSString *name, void (^block)()) {
+void fexample(NSString *name, void (^block)(void)) {
   fit(name, block);
 }
 
-void specify(NSString *name, void (^block)()) {
+void specify(NSString *name, void (^block)(void)) {
   it(name, block);
 }
 
-void fspecify(NSString *name, void (^block)()) {
+void fspecify(NSString *name, void (^block)(void)) {
   fit(name, block);
 }
 
-void beforeAll(void (^block)()) {
+void beforeAll(void (^block)(void)) {
   SPTReturnUnlessBlockOrNil(block);
   [SPTCurrentGroup addBeforeAllBlock:block];
 }
 
-void afterAll(void (^block)()) {
+void afterAll(void (^block)(void)) {
   SPTReturnUnlessBlockOrNil(block);
   [SPTCurrentGroup addAfterAllBlock:block];
 }
 
-void beforeEach(void (^block)()) {
+void beforeEach(void (^block)(void)) {
   SPTReturnUnlessBlockOrNil(block);
   [SPTCurrentGroup addBeforeEachBlock:block];
 }
 
-void afterEach(void (^block)()) {
+void afterEach(void (^block)(void)) {
   SPTReturnUnlessBlockOrNil(block);
   [SPTCurrentGroup addAfterEachBlock:block];
 }
 
-void before(void (^block)()) {
+void before(void (^block)(void)) {
   beforeEach(block);
 }
 
-void after(void (^block)()) {
+void after(void (^block)(void)) {
   afterEach(block);
 }
 

--- a/Specta/Specta/XCTestCase+Specta.m
+++ b/Specta/Specta/XCTestCase+Specta.m
@@ -38,7 +38,7 @@
 }
 
 - (void)spt_dequeueFailures {
-  void(^dequeueFailures)() = ^() {
+  void(^dequeueFailures)(void) = ^() {
     [self spt_dequeueFailures];
   };
 


### PR DESCRIPTION
Fixes the Xcode 9 warning `This block declaration is not a prototype.`. See [this SO post](https://stackoverflow.com/questions/44473146/this-function-declaration-is-not-a-prototype-warning-in-xcode-9).